### PR TITLE
Fix bug: "TypeName specified for parameter '@table'.  

### DIFF
--- a/Tests/TypeProvider.Test.fs
+++ b/Tests/TypeProvider.Test.fs
@@ -91,3 +91,14 @@ let tableValuedSprocTupleNull() =
     Assert.Equal((1, None), cmd.Execute())    
     ()
 
+type ColumnsShouldNotBeNull2 = SqlCommand<"""SELECT COLUMN_NAME, IS_NULLABLE, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_NAME = 'DatabaseLog' and numeric_precision is null
+ORDER BY ORDINAL_POSITION""", connectionString, SingleRow = true>
+
+[<Fact>]
+let columnsShouldNotBeNull2() = 
+    let cmd = new ColumnsShouldNotBeNull2()
+    let _,_,_,_,precision = cmd.Execute()
+    Assert.Equal(None, precision)    
+    ()


### PR DESCRIPTION
... TypeName must only be set for Structured parameters."

I started fixing this bug that TVPs caused, it was caused by the new test in this PR. 
This sent me on a refactoring trip! 

Now using Union cases / Records to pass params around instead of string concat/split. To me this is more readable. 

What do you think of the changes?
