### PR TITLE
SingleRow parameter removed in favor of a enum where you can specify:

### DIFF
--- a/src/SqlCommandProvider.Tests/ExpectedRows.fs
+++ b/src/SqlCommandProvider.Tests/ExpectedRows.fs
@@ -1,0 +1,28 @@
+﻿module FSharp.Data.Experimental.Tests.ExpectedRows 
+
+open FSharp.Data.Experimental
+open Xunit
+
+[<Literal>]
+let connectionString = @"Data Source=(LocalDb)\v11.0;Initial Catalog=AdventureWorks2012;Integrated Security=True"
+
+type ResultTypeMapsWithNullableCols = 
+    SqlCommand<"SELECT LastName FROM Person.Person WHERE BusinessEntityID=@id", "name=AdventureWorks2012", ResultRows = ExpectedRows.OneOrZero>
+
+[<Fact>]
+let ExpectedRowsOneOrZeroReturnsNone() = 
+    let cmd = ResultTypeMapsWithNullableCols()
+    let expected : string option = None
+    let b = cmd.Execute -1
+    Assert.Equal(expected, b)
+
+[<Fact>]
+let ExpectedRowsOneOrZeroReturnsSome() = 
+    let cmd = ResultTypeMapsWithNullableCols()
+    let expected = Some "Sánchez"
+    let b = cmd.Execute 1
+    Assert.Equal(expected, b)
+
+    
+
+

--- a/src/SqlCommandProvider.Tests/Input.Test.fs
+++ b/src/SqlCommandProvider.Tests/Input.Test.fs
@@ -7,7 +7,7 @@ open Xunit
 type QueryWithNullableParam = 
     SqlCommand<"declare @yCopy as int = @y
         SELECT Result = @x + CASE WHEN @yCopy IS NULL THEN 1 ELSE @yCopy END
-    ","name=AdventureWorks2012", SingleRow = true, AllParametersOptional = true>
+    ","name=AdventureWorks2012", ResultRows=ExpectedRows.ExactlyOne, AllParametersOptional = true>
 
 [<Fact>]
 let BothOptinalParamsSupplied() = 

--- a/src/SqlCommandProvider.Tests/SqlCommandProvider.Tests.fsproj
+++ b/src/SqlCommandProvider.Tests/SqlCommandProvider.Tests.fsproj
@@ -58,6 +58,7 @@
     <Compile Include="Input.Test.fs" />
     <Compile Include="TypeProvider.Test.fs" />
     <Compile Include="ResultType.fs" />
+    <Compile Include="ExpectedRows.fs" />
     <None Include="app.config" />
     <None Include="Test.fsx" />
     <None Include="sampleCommand.sql" />

--- a/src/SqlCommandProvider.Tests/TVP.fs
+++ b/src/SqlCommandProvider.Tests/TVP.fs
@@ -5,7 +5,7 @@ open System.Data
 open Xunit
 
 // If compile fails here, check prereqs.sql
-type TableValuedTuple = SqlCommand<"exec myProc @x", "name=AdventureWorks2012", SingleRow = true>
+type TableValuedTuple = SqlCommand<"exec myProc @x", "name=AdventureWorks2012", ResultRows = ExpectedRows.ExactlyOne>
 type MyTableType = TableValuedTuple.MyTableType
 
 [<Fact>]
@@ -52,7 +52,7 @@ let tableValuedSingle() =
     let result = cmd.Execute(x = p) |> List.ofSeq
     Assert.Equal<int list>([1;2], result)    
 
-type TableValuedSprocTuple  = SqlCommand<"myProc", ConnectionStringOrName = "name=AdventureWorks2012", SingleRow = true, CommandType = CommandType.StoredProcedure>
+type TableValuedSprocTuple  = SqlCommand<"myProc", ConnectionStringOrName = "name=AdventureWorks2012", ResultRows = ExpectedRows.ExactlyOne, CommandType = CommandType.StoredProcedure>
 
 [<Fact>]
 let tableValuedSprocTupleValue() = 

--- a/src/SqlCommandProvider.Tests/TypeProvider.Test.fs
+++ b/src/SqlCommandProvider.Tests/TypeProvider.Test.fs
@@ -7,14 +7,14 @@ open Xunit
 [<Literal>]
 let connectionString = @"Data Source=(LocalDb)\v11.0;Initial Catalog=AdventureWorks2012;Integrated Security=True"
 
-type QueryWithTinyInt = SqlCommand<"SELECT CAST(10 AS TINYINT) AS Value", connectionString, SingleRow = true>
+type QueryWithTinyInt = SqlCommand<"SELECT CAST(10 AS TINYINT) AS Value", connectionString, ResultRows = ExpectedRows.ExactlyOne>
 
 [<Fact>]
 let TinyIntConversion() = 
     let cmd = QueryWithTinyInt()
     Assert.Equal(Some 10uy, cmd.Execute())    
 
-type GetServerTime = SqlCommand<"IF @Bit = 1 SELECT 'TRUE' ELSE SELECT 'FALSE'", connectionString, SingleRow=true>
+type GetServerTime = SqlCommand<"IF @Bit = 1 SELECT 'TRUE' ELSE SELECT 'FALSE'", connectionString, ResultRows = ExpectedRows.ExactlyOne>
 
 [<Fact>]
 let SqlCommandClone() = 
@@ -31,7 +31,7 @@ let SqlCommandClone() =
     cmdClone.CommandText <- "SELECT 0"
     Assert.Equal<string>("TRUE", cmd.Execute(Bit = 1))    
 
-type ConditionalQuery = SqlCommand<"IF @flag = 0 SELECT 1, 'monkey' ELSE SELECT 2, 'donkey'", connectionString, SingleRow=true>
+type ConditionalQuery = SqlCommand<"IF @flag = 0 SELECT 1, 'monkey' ELSE SELECT 2, 'donkey'", connectionString, ResultRows = ExpectedRows.ExactlyOne>
 
 [<Fact>]
 let ConditionalQuery() = 
@@ -43,7 +43,7 @@ type ColumnsShouldNotBeNull2 =
     SqlCommand<"SELECT COLUMN_NAME, IS_NULLABLE, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION
             FROM INFORMATION_SCHEMA.COLUMNS
             WHERE TABLE_NAME = 'DatabaseLog' and numeric_precision is null
-            ORDER BY ORDINAL_POSITION", connectionString, SingleRow = true>
+            ORDER BY ORDINAL_POSITION", connectionString, ResultRows = ExpectedRows.ExactlyOne>
 
 [<Fact>]
 let columnsShouldNotBeNull2() = 


### PR DESCRIPTION
SingleRow parameter removed in favor of a enum where you can specify:
- ExpectedRows.Many (Same as SingleRow = false)
- ExpectedRows.ExactlyOne (Same as SingleRow = true)
- ExpectedRows.OneOrZero (Returns an option, None if no rows are returned, Some if one or more rows are returned)

What do you think? Good or bad idea? :)

(This is my first pull request ever, so be nice ;)
