### PR TITLE
add documentation for creating MDF files dynamically 

### DIFF
--- a/docs/content/dynamic local db.fsx
+++ b/docs/content/dynamic local db.fsx
@@ -1,5 +1,5 @@
 (*** hide ***)
-#r "../../bin/FShapr.Data.SqlClient.dll"
+#r "../../bin/FSharp.Data.SqlClient.dll"
 #r "../../bin/Microsoft.SqlServer.Types.dll"
 
 (**
@@ -10,7 +10,7 @@ Sometimes you don't want to have to be online just to compile your programs. Wit
 .MDF file as the compile time connection string, and then change your connection string at runtime when you deploy your application.
 *)
 
-open FShapr.Data
+open FSharp.Data
 
 [<Literal>]
 let connectionString=@"Data Source=(LocalDB)\v11.0;AttachDbFilename=C:\git\Project1\Database1.mdf;Integrated Security=True;Connect Timeout=10"


### PR DESCRIPTION
This is just some documentation about how to use a local schema file (schema.sql) to generate an MDF so you can compile locally without an internet connection, and manage your schema with a text file rather than a binary file.  Useful for multiple developers working on the same database and doing diff/merge
