### PR TITLE
minor refactoring of duplicated string literals used for connection strings

### DIFF
--- a/src/SqlClient.Tests/Ado.fsx
+++ b/src/SqlClient.Tests/Ado.fsx
@@ -1,9 +1,10 @@
-﻿open System
+﻿#load "ConnectionStrings.fs"
+open System
 open System.Data
 open System.Data.SqlClient
 
 let getComponents (productId ,checkDate) = 
-    use connection = new SqlConnection(@"Data Source=(LocalDb)\v11.0;Initial Catalog=AdventureWorks2012;Integrated Security=True")
+    use connection = new SqlConnection(ConnectionStrings.AdventureWorks)
 
     let sqlCommand = new SqlCommand("dbo.uspGetWhereUsedProductID", connection)
     sqlCommand.CommandType <- CommandType.StoredProcedure

--- a/src/SqlClient.Tests/ConnectionStrings.fs
+++ b/src/SqlClient.Tests/ConnectionStrings.fs
@@ -1,0 +1,12 @@
+﻿module ConnectionStrings
+
+    [<Literal>]
+    let AdventureWorks = @"name=AdventureWorks2012"
+    [<Literal>]
+    let AdventureWorksAzure = @"Server=tcp:mhknbn2kdz.database.windows.net,1433;Database=AdventureWorks2012;User ID=sqlfamily;Password= sqlf@m1ly;Trusted_Connection=False;Encrypt=True;Connection Timeout=30"
+    [<Literal>]
+    let ThermionAzure = "Server=tcp:j02n9a9uk7.database.windows.net,1433;Database=Thermion;User ID=SQLAdmin;Password=f2rACP?ed_:*Hj2A;Trusted_Connection=False;Encrypt=True;Connection Timeout=30;Max Pool Size=1000;"
+    [<Literal>]
+    let MasterDb = @"name=MasterDb"
+    [<Literal>]
+    let LocalDbDefault = @"Data Source=(LocalDb)\v11.0;Integrated Security=True"

--- a/src/SqlClient.Tests/OptionalParamsTests.fs
+++ b/src/SqlClient.Tests/OptionalParamsTests.fs
@@ -1,15 +1,13 @@
 ﻿module FSharp.Data.OptionalParamsTests
 
-open System
-open System.Data
 open Xunit
 open FsUnit.Xunit
 
 [<Literal>]
-let connectionString = @"name=AdventureWorks2012"
+let connectionString = ConnectionStrings.AdventureWorks
 
 type QueryWithNullableParam = 
-    SqlCommandProvider<"SELECT CAST(@x AS INT) + ISNULL(CAST(@y AS INT), 1)",connectionString, SingleRow = true, AllParametersOptional = true>
+    SqlCommandProvider<"SELECT CAST(@x AS INT) + ISNULL(CAST(@y AS INT), 1)", connectionString, SingleRow = true, AllParametersOptional = true>
 
 [<Fact>]
 let BothOptinalParamsSupplied() = 
@@ -24,12 +22,9 @@ let SkipYParam() =
 type NullableStringInput = SqlCommandProvider<"select ISNULL(CAST(@P1 AS VARCHAR), '')", connectionString, SingleRow = true, AllParametersOptional = true>
 type NullableStringInputStrict = SqlCommandProvider<"select ISNULL(CAST(@P1 AS VARCHAR), '')", connectionString, SingleRow = true>
 
-open System.Data.SqlClient
-
 [<Fact>]
 let NullableStringInputParameter() = 
     (new NullableStringInput()).Execute(None) |> should equal (Some "")
     (new NullableStringInput()).Execute() |> should equal (Some "")
     (new NullableStringInputStrict()).Execute(null) |> should equal (Some "")
     (new NullableStringInput()).Execute(Some "boo") |> should equal (Some "boo")
-

--- a/src/SqlClient.Tests/ProgrammabilityTests.fs
+++ b/src/SqlClient.Tests/ProgrammabilityTests.fs
@@ -4,8 +4,8 @@ open Xunit
 open FsUnit.Xunit
 
 [<Literal>] 
-//let connectionString = @"Server=tcp:mhknbn2kdz.database.windows.net,1433;Database=AdventureWorks2012;User ID=sqlfamily;Password= sqlf@m1ly;Trusted_Connection=False;Encrypt=True;Connection Timeout=30"
-let connectionString = @"name = AdventureWorks2012"
+//let connectionString = ConnectionStrings.AdventureWorksAzure
+let connectionString = ConnectionStrings.AdventureWorks
 
 type AdventureWorks = SqlProgrammabilityProvider<connectionString>
 

--- a/src/SqlClient.Tests/ResultTypeTests.fs
+++ b/src/SqlClient.Tests/ResultTypeTests.fs
@@ -1,13 +1,10 @@
 ﻿module FSharp.Data.ResultTypeTests
 
-open System.Transactions
-open System.Data.SqlClient
 open FSharp.Data
 open Xunit
-open FsUnit.Xunit
 
 [<Literal>]
-let connectionString = @"Data Source=(LocalDb)\v11.0;Initial Catalog=AdventureWorks2012;Integrated Security=True"
+let connectionString = ConnectionStrings.AdventureWorks
 
 [<Literal>]
 let command = "SELECT * FROM (VALUES ('F#', 2005), ('Scala', 2003), ('foo bar',NULL))  AS T(lang, DOB)"

--- a/src/SqlClient.Tests/Schema.fsx
+++ b/src/SqlClient.Tests/Schema.fsx
@@ -1,10 +1,9 @@
 ﻿module Test.Schema
 
-open System.Data
 open System.Data.SqlClient
-
+#load "ConnectionStrings.fs"
 [<Literal>]
-let connectionString = @"Server=tcp:mhknbn2kdz.database.windows.net,1433;Database=AdventureWorks2012;User ID=sqlfamily;Password= sqlf@m1ly;Trusted_Connection=False;Encrypt=True;Connection Timeout=30"
+let connectionString = ConnectionStrings.AdventureWorksAzure
 
 let conn = new SqlConnection(connectionString)
 do conn.Open()
@@ -34,4 +33,3 @@ let DataTypes() =
                     yield string row.["TypeName"],  unbox<int> row.["ProviderDbType"], string row.["DataType"]
     }
     |> Seq.iter (printfn "%A")
-

--- a/src/SqlClient.Tests/SpatialTypesTests.fs
+++ b/src/SqlClient.Tests/SpatialTypesTests.fs
@@ -5,7 +5,7 @@ open Microsoft.SqlServer.Types
 open System.Data.SqlTypes
 
 [<Literal>]
-let connectionString = @"Data Source=(LocalDb)\v11.0;Initial Catalog=AdventureWorks2012;Integrated Security=True"
+let connectionString = ConnectionStrings.AdventureWorks
 
 type GetEmployeeByLevel = SqlCommandProvider<"SELECT OrganizationNode FROM HumanResources.Employee WHERE OrganizationNode = @OrganizationNode", connectionString, SingleRow = true>
 [<Fact>]

--- a/src/SqlClient.Tests/SqlClient.Tests.fsproj
+++ b/src/SqlClient.Tests/SqlClient.Tests.fsproj
@@ -54,6 +54,7 @@
   <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <ItemGroup>
+    <Compile Include="ConnectionStrings.fs" />
     <Compile Include="ConfigurationTest.fs" />
     <Compile Include="OptionalParamsTests.fs" />
     <Compile Include="TypeProviderTest.fs" />

--- a/src/SqlClient.Tests/SqlClientExtensionsTests.fs
+++ b/src/SqlClient.Tests/SqlClientExtensionsTests.fs
@@ -11,10 +11,9 @@ open FSharp.Data.SqlClient
 
 type ExtensionsTest() = 
     
-    [<Literal>]
-    let connectionString = @"Data Source=(LocalDb)\v11.0;Initial Catalog=AdventureWorks2012;Integrated Security=True"
-    //let connectionString = @"Server=tcp:mhknbn2kdz.database.windows.net,1433;Database=AdventureWorks2012;User ID=sqlfamily;Password= sqlf@m1ly;Trusted_Connection=False;Encrypt=True;Connection Timeout=30"
-    let conn = new SqlConnection(connectionString)
+    //[<Literal>]
+    //let connectionString = ConnectionStrings.AdventureWorksAzure
+    let conn = new SqlConnection(ConnectionStrings.AdventureWorks)
     do
         conn.Open()
         conn.LoadDataTypesMap()
@@ -65,7 +64,3 @@ type ExtensionsTest() =
         Assert.Equal(system_type_id, t.SqlEngineTypeId)
         Assert.Equal(user_type_id, t.UserTypeId)
         Assert.Empty(t.UdttName)
-        
-
-
-

--- a/src/SqlClient.Tests/SqlCommand.fsx
+++ b/src/SqlClient.Tests/SqlCommand.fsx
@@ -2,13 +2,12 @@
     Use cases
 *)
 #r "../../bin/FSharp.Data.SqlClient.dll"
-
+#load "ConnectionStrings.fs"
 open System
-open System.Data
 open FSharp.Data
 
 [<Literal>] 
-let connectionString = @"Data Source=(LocalDb)\v11.0;Initial Catalog=AdventureWorks2012;Integrated Security=True;MultipleActiveResultSets=True"
+let connectionString = ConnectionStrings.AdventureWorks
 
 [<Literal>]
 let queryProductsSql = "
@@ -19,7 +18,7 @@ WHERE SellStartDate > @SellStartDate
 
 //Custom record types and connection string override
 type QueryProducts = SqlCommandProvider<queryProductsSql, connectionString>
-let cmd1 = new QueryProducts(connectionString = @"Data Source=(LocalDb)\v11.0;Initial Catalog=AdventureWorks2012;Integrated Security=True")
+let cmd1 = new QueryProducts(connectionString = ConnectionStrings.AdventureWorks)
 let result1 : Async<QueryProducts.Record seq> = cmd1.AsyncExecute(top = 7L, SellStartDate = System.DateTime.Parse "2002-06-01")
 result1 |> Async.RunSynchronously |> Seq.iter (fun x -> printfn "Product name: %s. Sells start date %A, size: %A" x.ProductName x.SellStartDate x.Size)
 let records = cmd1.Execute(top = 7L, SellStartDate = System.DateTime.Parse "2002-06-01") |> List.ofSeq
@@ -133,11 +132,11 @@ let getEmployeeByLevel = new GetEmployeeByLevel()
 getEmployeeByLevel.Execute(2s)
 
 
-type MyCommand1 = SqlCommandProvider<"SELECT GETDATE() AS Now, GETUTCDATE() AS UtcNow",  @"Data Source=(LocalDb)\v11.0;Integrated Security=True">
+type MyCommand1 = SqlCommandProvider<"SELECT GETDATE() AS Now, GETUTCDATE() AS UtcNow",  ConnectionStrings.LocalDbDefault>
 type MyRecord1 = MyCommand1.Record
 let r1 = MyCommand1.Record(DateTime.Now, DateTime.UtcNow)
 
-type MyCommand2 = SqlCommandProvider<"SELECT GETDATE() AS Now, GETUTCDATE() AS UtcNow",  @"Data Source=(LocalDb)\v11.0;Integrated Security=True">
+type MyCommand2 = SqlCommandProvider<"SELECT GETDATE() AS Now, GETUTCDATE() AS UtcNow",  ConnectionStrings.LocalDbDefault>
 let r2 = MyCommand2.Record(DateTime.Now, DateTime.UtcNow)
 
 type MyRecord = { Now: DateTime; UtcNow: DateTime }

--- a/src/SqlClient.Tests/SqlEnumTests.fs
+++ b/src/SqlClient.Tests/SqlEnumTests.fs
@@ -1,14 +1,14 @@
 ﻿namespace FSharp.Data
 
-type EnumMapping = SqlEnumProvider<"SELECT * FROM (VALUES(('One'), 1), ('Two', 2)) AS T(Tag, Value)", @"Data Source=(LocalDb)\v11.0;Integrated Security=True", CLIEnum = true>
+type EnumMapping = SqlEnumProvider<"SELECT * FROM (VALUES(('One'), 1), ('Two', 2)) AS T(Tag, Value)", ConnectionStrings.LocalDbDefault, CLIEnum = true>
 
 module EnumTests = 
 
     open System
     open Xunit
-
+    
     [<Literal>]
-    let connectionString = @"Data Source=(LocalDb)\v11.0;Integrated Security=True"
+    let connectionString = ConnectionStrings.LocalDbDefault
 
     type TinyIntMapping = SqlEnumProvider<"SELECT * FROM (VALUES(('One'), CAST(1 AS tinyint)), ('Two', CAST(2 AS tinyint))) AS T(Tag, Value)", connectionString>
 
@@ -39,4 +39,3 @@ module EnumTests =
         let value = TinyIntMapping.One
         Assert.Equal(Some "One", TinyIntMapping.TryFindName value)
         Assert.Equal(None, TinyIntMapping.TryFindName Byte.MinValue)
-

--- a/src/SqlClient.Tests/SqlProgrammability.fsx
+++ b/src/SqlClient.Tests/SqlProgrammability.fsx
@@ -1,18 +1,18 @@
     
 #r "../../bin/Fsharp.Data.SqlClient.dll"
 #r "../../bin/Microsoft.SqlServer.Types.dll"
-
+#load "ConnectionStrings.fs"
 open System
 open System.Data
 open FSharp.Data
-open Microsoft.SqlServer.Types
+
 
 [<Literal>] 
-let connectionString = @"Data Source=(LocalDb)\v11.0;Initial Catalog=AdventureWorks2012;Integrated Security=True"
-//let connectionString = @"Server=tcp:mhknbn2kdz.database.windows.net,1433;Database=AdventureWorks2012;User ID=sqlfamily;Password= sqlf@m1ly;Trusted_Connection=False;Encrypt=True;Connection Timeout=30"
+let connectionString = ConnectionStrings.AdventureWorks
+//let connectionString = ConnectionStrings.AdventureWorksAzure
 
 [<Literal>] 
-let prodConnectionString = @"Data Source=(LocalDb)\v11.0;Initial Catalog=master;Integrated Security=True"
+let prodConnectionString = ConnectionStrings.MasterDb
 
 type AdventureWorks2012 = SqlProgrammabilityProvider<connectionString>
 type dbo = AdventureWorks2012.dbo
@@ -127,7 +127,7 @@ let res = updateEmployeeLogin.AsyncExecute()
 
 //let x = new Run
 
-type Db = SqlProgrammabilityProvider<"Server=tcp:j02n9a9uk7.database.windows.net,1433;Database=Thermion;User ID=SQLAdmin;Password=f2rACP?ed_:*Hj2A;Trusted_Connection=False;Encrypt=True;Connection Timeout=30;Max Pool Size=1000;">
+type Db = SqlProgrammabilityProvider<ConnectionStrings.ThermionAzure>
 type Asset = Db.Thermion.Tables.Asset
 let table  = new Asset()
 table.AddRow(Guid.NewGuid(), "w-1", "well", "well", "hathaway", 1)

--- a/src/SqlClient.Tests/TVPTests.fs
+++ b/src/SqlClient.Tests/TVPTests.fs
@@ -1,13 +1,12 @@
 ﻿module FSharp.Data.TVPTests
 
 open FSharp.Data
-open System.Data
 open Xunit
 
-type Get42FromMasterDb = SqlCommandProvider<"SELECT 42", @"Data Source=(LocalDb)\v11.0;Initial Catalog=master;Integrated Security=True">
+type Get42FromMasterDb = SqlCommandProvider<"SELECT 42", ConnectionStrings.MasterDb>
 
 // If compile fails here, check prereqs.sql
-type TableValuedTuple = SqlCommandProvider<"exec Person.myProc @x", "name=AdventureWorks2012", SingleRow = true, ResultType = ResultType.Tuples>
+type TableValuedTuple = SqlCommandProvider<"exec Person.myProc @x", ConnectionStrings.AdventureWorks, SingleRow = true, ResultType = ResultType.Tuples>
 type MyTableType = TableValuedTuple.MyTableType
 
 [<Fact>]
@@ -41,7 +40,7 @@ let NullableColumn() =
     Assert.Equal(Some(1, None), cmd.Execute p)    
 
 
-type TableValuedSingle = SqlCommandProvider<"exec SingleElementProc @x", ConnectionStringOrName = "name=AdventureWorks2012">
+type TableValuedSingle = SqlCommandProvider<"exec SingleElementProc @x", ConnectionStringOrName = ConnectionStrings.AdventureWorks>
 
 [<Fact>]
 let SingleColumn() = 
@@ -64,7 +63,7 @@ let tvpSqlParamCleanUp() =
     let result = cmd.Execute(x = p) |> List.ofSeq
     Assert.Equal<int list>([1;2], result)    
 
-type TableValuedSprocTuple  = SqlCommandProvider<"exec Person.myProc @x", ConnectionStringOrName = "name=AdventureWorks2012", SingleRow = true, ResultType = ResultType.Tuples>
+type TableValuedSprocTuple  = SqlCommandProvider<"exec Person.myProc @x", ConnectionStringOrName = ConnectionStrings.AdventureWorks, SingleRow = true, ResultType = ResultType.Tuples>
 
 [<Fact>]
 let SprocTupleValue() = 
@@ -76,7 +75,7 @@ let SprocTupleValue() =
     let actual = cmd.Execute(p).Value
     Assert.Equal((1, Some "monkey"), actual)    
 
-type TableValuedTupleWithOptionalParams = SqlCommandProvider<"exec Person.myProc @x", "name=AdventureWorks2012", AllParametersOptional = true>
+type TableValuedTupleWithOptionalParams = SqlCommandProvider<"exec Person.myProc @x", ConnectionStrings.AdventureWorks, AllParametersOptional = true>
 [<Fact>]
 let TableValuedTupleWithOptionalParams() = 
     let cmd = new TableValuedTupleWithOptionalParams()

--- a/src/SqlClient.Tests/TransactionTests.fs
+++ b/src/SqlClient.Tests/TransactionTests.fs
@@ -10,7 +10,7 @@ open Xunit
 open FSharp.Data.TypeProviderTest
 
 [<Literal>]
-let connectionString = @"Data Source=(LocalDb)\v11.0;Initial Catalog=AdventureWorks2012;Integrated Security=True"
+let connectionString = ConnectionStrings.AdventureWorks
 
 [<Fact>]
 let ``Closing connection on complete``() =

--- a/src/SqlClient.Tests/TypeProviderTest.fs
+++ b/src/SqlClient.Tests/TypeProviderTest.fs
@@ -7,7 +7,7 @@ open Xunit
 open FsUnit.Xunit
 
 [<Literal>]
-let connectionString = @"Data Source=(LocalDb)\v11.0;Initial Catalog=AdventureWorks2012;Integrated Security=True"
+let connectionString = ConnectionStrings.AdventureWorks
 
 type GetOddNumbers = SqlCommandProvider<"select * from (values (2), (4), (8), (24)) as T(value)", connectionString>
 

--- a/src/SqlClient.Tests/app.config
+++ b/src/SqlClient.Tests/app.config
@@ -14,6 +14,7 @@
   </runtime>
   <connectionStrings>
     <add name="AdventureWorks2012" connectionString="Data Source=(LocalDb)\v11.0;Initial Catalog=AdventureWorks2012;Integrated Security=True" />
+    <add name="MasterDb" connectionString="Data Source=(LocalDb)\v11.0;Initial Catalog=master;Integrated Security=True" />
   </connectionStrings>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />


### PR DESCRIPTION
I think it's helpful for development when configuration is a bit different than default one, just two places to changes:

app.config
ConnectionStrings.fs

instead of changing connection strings in most of the test files.