### PR TITLE
Remove ResolutionFolder parameter

### DIFF
--- a/docs/content/configuration and Input.fsx
+++ b/docs/content/configuration and Input.fsx
@@ -18,7 +18,6 @@ SqlCommandProvider parameters
   <tr><td class="title">SingleRow</td><td>false</td><td>true/false</td></tr>
   <tr><td class="title">ConfigFile</td><td>app.config or web.config</td><td>Valid file name</td></tr>
   <tr><td class="title">AllParametersOptional</td><td>false</td><td>true/false</td></tr>
-  <tr><td class="title">ResolutionFolder</td><td>The folder that contains the project or script.</td><td>Valid file system path. Absolute or relative.</td></tr>
 </tbody>
 </table>
 
@@ -31,7 +30,6 @@ SqlProgrammabilityProvider parameters
   <tr><td class="title">ConnectionStringOrName</td><td>-</td><td>Connection string or name</td></tr>
   <tr><td class="title">ResultType</td><td>ResultType.Records</td><td>Tuples, Records, DataTable, or DataReader</td></tr>
   <tr><td class="title">ConfigFile</td><td>app.config or web.config</td><td>valid file name</td></tr>
-  <tr><td class="title">ResolutionFolder</td><td>The folder that contains the project or script.</td><td>Valid file system path. Absolute or relative.</td></tr>
 </tbody>
 </table>
 
@@ -81,7 +79,7 @@ type FibonacciQuery = SqlCommandProvider<fibonacci, connectionString>
 (**
 ### External *.sql file
 
-An ability to use external \*.sql file instead of inline strings can improve developement expirience.
+An ability to use external \*.sql file instead of inline strings can improve developement experience.
 Visual Studio has rich tooling support for *.sql files. (via SQL Server Data Tools) 
 
 <img src="img/sql_file_As_CommandText_1.png"/>

--- a/docs/content/index.fsx
+++ b/docs/content/index.fsx
@@ -124,7 +124,6 @@ SqlCommandProvider and SqlProgrammabilityProvider features at glance
     * Connection string is either literal or name from config file (app.config is default for config file)
     * Connection string can be overridden at run-time via constructor optional parameter
     * Constructor optionally accepts `SqlTransaction` and uses associated connection to execute command
-    * "ResolutionFolder" parameter - a folder to be used to resolve relative file paths at compile time. Applied to command text *.sql files only.
 * Input:
     * Unbound sql variables/input parameters mapped to mandatory typed arguments for `AsyncExecute/Execute`
     * Set `AllParametersOptional` to true to make all parameters optional (nullable) (`SqlCommandProvider<...>` only)

--- a/src/SqlClient.Samples/WebApi.Controllers/DataAccess.fs
+++ b/src/SqlClient.Samples/WebApi.Controllers/DataAccess.fs
@@ -5,7 +5,7 @@ open FSharp.Data
 [<Literal>]
 let AdventureWorks2012 = "name=AdventureWorks2012"
 
-type QueryProducts = SqlCommandProvider<"T-SQL\Products.sql", AdventureWorks2012, DataDirectory = "App_Data">
+type QueryProducts = SqlCommandProvider<"T-SQL/Products.sql", AdventureWorks2012, DataDirectory = "App_Data">
 
 type AdventureWorks = SqlProgrammabilityProvider<AdventureWorks2012, DataDirectory = "App_Data">
 

--- a/src/SqlClient.Tests/ConfigurationTest.fs
+++ b/src/SqlClient.Tests/ConfigurationTest.fs
@@ -26,6 +26,6 @@ let RuntimeConfig () =
     Configuration.GetConnectionStringAtRunTime name
     |> should equal ConfigurationManager.ConnectionStrings.[name].ConnectionString
 
-type Get42RelativePath = SqlCommandProvider<"sampleCommand.sql", "name=AdventureWorks2012", ResolutionFolder="MySqlFolder">
+type Get42RelativePath = SqlCommandProvider<"MySqlFolder/sampleCommand.sql", "name=AdventureWorks2012">
 
 type Get42 = SqlCommandProvider<"SELECT 42", "name=AdventureWorks2012", ConfigFile = "appWithInclude.config">

--- a/src/SqlClient/Configuration.fs
+++ b/src/SqlClient/Configuration.fs
@@ -31,9 +31,10 @@ type Configuration() =
             then commandTextOrPath, None
             else
                 if  Path.GetExtension(commandTextOrPath) <> ".sql" then failwith "Only files with .sql extension are supported"
-                let watcher = new FileSystemWatcher(Filter = commandTextOrPath, Path = resolutionFolder)
+                let watcher = new FileSystemWatcher(Filter = Path.GetFileName(path), Path = Path.GetDirectoryName(path))
                 watcher.Changed.Add(fun _ -> invalidateCallback())
                 watcher.Renamed.Add(fun _ -> invalidateCallback())
+                watcher.Deleted.Add(fun _ -> invalidateCallback())
                 watcher.EnableRaisingEvents <- true   
                 let task = Task.Factory.StartNew(fun () -> 
                         use stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)

--- a/src/SqlClient/Configuration.fs
+++ b/src/SqlClient/Configuration.fs
@@ -26,7 +26,7 @@ type Configuration() =
         if isInvalidPathChars.Overlaps( commandTextOrPath)         
         then commandTextOrPath, None
         else
-            let path = Path.Combine(resolutionFolder, commandTextOrPath)
+            let path = Path.GetFullPath(Path.Combine(resolutionFolder, commandTextOrPath))
             if File.Exists(path) |> not 
             then commandTextOrPath, None
             else


### PR DESCRIPTION
Fix FileSystemWatcher so that it works with rooted and partial paths
You can now also #load a .fs file from a different folder and it will still work
Fixes #110.