### PR TITLE
Make FileSystemWatcher more reliable

### DIFF
--- a/src/SqlClient.Samples/WebApi.Controllers/DataAccess.fs
+++ b/src/SqlClient.Samples/WebApi.Controllers/DataAccess.fs
@@ -5,7 +5,7 @@ open FSharp.Data
 [<Literal>]
 let AdventureWorks2012 = "name=AdventureWorks2012"
 
-type QueryProducts = SqlCommandProvider<"T-SQL\Products.sql", AdventureWorks2012, DataDirectory = "App_Data">
+type QueryProducts = SqlCommandProvider<"T-SQL/Products.sql", AdventureWorks2012, DataDirectory = "App_Data">
 
 type AdventureWorks = SqlProgrammabilityProvider<AdventureWorks2012, DataDirectory = "App_Data">
 

--- a/src/SqlClient.Tests/ConfigurationTest.fs
+++ b/src/SqlClient.Tests/ConfigurationTest.fs
@@ -26,6 +26,15 @@ let RuntimeConfig () =
     Configuration.GetConnectionStringAtRunTime name
     |> should equal ConfigurationManager.ConnectionStrings.[name].ConnectionString
 
+[<Fact>]
+let CheckValidFileName() = 
+    let expected = Some "c:\\mysqlfiles\\test.sql"
+    Configuration.GetValidFileName("test.sql", "c:\\mysqlfiles") |> should equal expected
+    Configuration.GetValidFileName("../test.sql", "c:\\mysqlfiles\\subfolder") |> should equal expected
+    Configuration.GetValidFileName("c:\\mysqlfiles/test.sql", "d:\\otherdrive") |> should equal expected
+    Configuration.GetValidFileName("../mysqlfiles/test.sql", "c:\\otherfolder") |> should equal expected
+    Configuration.GetValidFileName("a/b/c/../../../test.sql", "c:\\mysqlfiles") |> should equal expected
+
 type Get42RelativePath = SqlCommandProvider<"sampleCommand.sql", "name=AdventureWorks2012", ResolutionFolder="MySqlFolder">
 
 type Get42 = SqlCommandProvider<"SELECT 42", "name=AdventureWorks2012", ConfigFile = "appWithInclude.config">


### PR DESCRIPTION
Fixes #110 

After a discussion in PR #112 we decided to not remove resolutionFolder because it helps when you expect your code to be `#load`ed from other folders. 
This PR just fixes the issue where you need to reopen the solution for changes to .sql files to be picked up.
