### PR TITLE
Add new constructor #107 / Fix sql command timeout behaviour #114

### DIFF
--- a/src/SqlClient.Tests/CommandTimeoutSetup.fs
+++ b/src/SqlClient.Tests/CommandTimeoutSetup.fs
@@ -1,0 +1,55 @@
+﻿module CommandTimeoutSetup
+
+open System.Data.SqlClient
+open Xunit
+open FSharp.Data.CreateCommandFunctorTests
+open FSharp.Data
+open System
+
+[<Literal>]
+let connection = ConnectionStrings.AdventureWorksLiteral
+
+ // just make sure we don't assert on the default value in the code whatever it is
+let customTimeout = (new Random()).Next(512, 1024)
+
+let prepareCommandWithConnectionContext =
+  use conn = new SqlConnection(connection)
+  conn.Open()
+  let createCommand() =
+    let c = conn.CreateCommand()
+    c.CommandTimeout <- customTimeout
+    c
+  new GetDate(createCommand)
+
+[<Fact>]
+let ``Setting the command timeout isn't overridden when giving connection context``() =
+    let getDate = prepareCommandWithConnectionContext
+    let sqlCommand = (getDate :> ISqlCommand).Raw
+    Assert.True(sqlCommand.CommandTimeout = customTimeout)
+
+[<Fact>]
+let ``Setting the command timeout is reflected in cloned command when giving connection context``() =
+    let getDate = prepareCommandWithConnectionContext
+    let sqlCommand = getDate.AsSqlCommand()
+    Assert.True(sqlCommand.CommandTimeout = customTimeout)
+
+[<Fact>]
+let ``Setting the command timeout is reflected when giving connection string``() =
+    let getDate = new GetDate(connection, customTimeout)
+    let sqlCommand = getDate.AsSqlCommand()
+    Assert.True(sqlCommand.CommandTimeout = customTimeout)
+    let sqlCommand = (getDate :> ISqlCommand).Raw
+    Assert.True(sqlCommand.CommandTimeout = customTimeout)
+
+[<Fact>]
+let ``Setting the command timeout is reflected when giving a transaction``() =
+    use cx = new SqlConnection(connection)
+    cx.Open()
+    use tx = cx.BeginTransaction()
+    let getDate = new GetDate(tx, customTimeout)
+    let sqlCommand = getDate.AsSqlCommand()
+    Assert.True(sqlCommand.CommandTimeout = customTimeout)
+    let sqlCommand = (getDate :> ISqlCommand).Raw
+    Assert.True(sqlCommand.CommandTimeout = customTimeout)
+
+// please add more tests here if new constructors are added to provided SqlCommand

--- a/src/SqlClient.Tests/CreateCommandFunctorTests.fs
+++ b/src/SqlClient.Tests/CreateCommandFunctorTests.fs
@@ -1,0 +1,28 @@
+module FSharp.Data.CreateCommandFunctorTests
+
+open System.Data.SqlClient
+
+open Xunit
+open FsUnit.Xunit
+
+open FSharp.Data.TypeProviderTest
+
+[<Literal>]
+let connection = ConnectionStrings.AdventureWorksLiteral
+
+type GetDate = SqlCommandProvider<"select getdate()", connection>
+
+[<Fact>]
+let asyncCustomRecord() =
+    use conn = new SqlConnection(connection)
+    conn.Open()
+    let createCommand = conn.CreateCommand
+    (new GetBitCoin(createCommand)).AsyncExecute("USD") |> Async.RunSynchronously |> Seq.length |> should equal 1
+
+[<Fact>]
+let singleRowOption() =
+    use conn = new SqlConnection(connection)
+    conn.Open()
+    let createCommand = conn.CreateCommand
+    (new NoneSingleton(createCommand)).Execute().IsNone |> should be True
+    (new SomeSingleton(createCommand)).AsyncExecute() |> Async.RunSynchronously |> should equal (Some 1)

--- a/src/SqlClient.Tests/SqlClient.Tests.fsproj
+++ b/src/SqlClient.Tests/SqlClient.Tests.fsproj
@@ -58,6 +58,7 @@
     <Compile Include="ConfigurationTest.fs" />
     <Compile Include="OptionalParamsTests.fs" />
     <Compile Include="TypeProviderTest.fs" />
+    <Compile Include="CreateCommandFunctorTests.fs" />
     <Compile Include="SpatialTypesTests.fs" />
     <Compile Include="TransactionTests.fs" />
     <Compile Include="ResultTypeTests.fs" />
@@ -68,8 +69,6 @@
     <Compile Include="SqlEnumTests.fs" />
     <Compile Include="DataTablesTests.fs" />
     <None Include="Schema.fsx" />
-    <Content Include="connectionStrings.config" />
-    <Content Include="appWithInclude.config" />
     <None Include="SqlCommand.fsx" />
     <None Include="SqlProgrammability.fsx" />
     <None Include="sampleCommand.sql" />
@@ -77,6 +76,8 @@
     <None Include="packages.config" />
     <None Include="Performance.fsx" />
     <None Include="Ado.fsx" />
+    <Content Include="appWithInclude.config" />
+    <Content Include="connectionStrings.config" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SqlClient.Tests/SqlClient.Tests.fsproj
+++ b/src/SqlClient.Tests/SqlClient.Tests.fsproj
@@ -59,6 +59,7 @@
     <Compile Include="OptionalParamsTests.fs" />
     <Compile Include="TypeProviderTest.fs" />
     <Compile Include="CreateCommandFunctorTests.fs" />
+    <Compile Include="CommandTimeoutSetup.fs" />
     <Compile Include="SpatialTypesTests.fs" />
     <Compile Include="TransactionTests.fs" />
     <Compile Include="ResultTypeTests.fs" />

--- a/src/SqlClient/ProvidedTypesHelper.fs
+++ b/src/SqlClient/ProvidedTypesHelper.fs
@@ -1,0 +1,14 @@
+﻿namespace ProviderImplementation
+
+open ProviderImplementation.ProvidedTypes
+
+module internal ProvidedTypesHelper =
+  let inline makeCtor parameters code =
+      let ctor = ProvidedConstructor parameters
+      ctor.InvokeCode <- code
+      ctor
+  let inline makeParamWithDefault n t d = ProvidedParameter(n, t, optionalValue = d)
+  let inline makeParam n t = ProvidedParameter(n, t)
+
+  
+

--- a/src/SqlClient/SqlClient.fsproj
+++ b/src/SqlClient/SqlClient.fsproj
@@ -69,6 +69,7 @@
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="ProvidedTypes.fsi" />
     <Compile Include="ProvidedTypes.fs" />
+    <Compile Include="ProvidedTypesHelper.fs" />
     <Compile Include="DebugProvidedTypes.fs" />
     <Compile Include="Configuration.fs" />
     <Compile Include="ProvidedTypesCache.fs" />

--- a/src/SqlClient/SqlCommand.fs
+++ b/src/SqlClient/SqlCommand.fs
@@ -127,7 +127,13 @@ type RuntimeSqlCommand (connection, commandTimeout, sqlStatement, isStoredProced
     member this.CommandTimeout = cmd.CommandTimeout
 
     member this.AsSqlCommand() = 
-        let clone = new SqlCommand(cmd.CommandText, new SqlConnection(cmd.Connection.ConnectionString), CommandType = cmd.CommandType)
+        let clone = 
+          new SqlCommand(
+            cmd.CommandText, 
+            new SqlConnection(cmd.Connection.ConnectionString), 
+            CommandType = cmd.CommandType,
+            CommandTimeout = cmd.CommandTimeout
+          )
         clone.Parameters.AddRange <| [| for p in cmd.Parameters -> SqlParameter(p.ParameterName, p.SqlDbType) |]
         clone
 


### PR DESCRIPTION
Ok, sorry for previous PR on which I merged master in my own repository rather than rebase.

This is the two patches I'm looking forward to integrate upstream/master:
* #107 new constructor to be able to pass a connection context / set the timeout in client code
* #114 fix the timeout not being setup in a cloned command