### PR TITLE
Fix for #190: SqlEnumProvider fails to compile when query has more than 2 fields.

### DIFF
--- a/src/SqlClient/SqlEnumProvider.fs
+++ b/src/SqlClient/SqlEnumProvider.fs
@@ -120,8 +120,15 @@ type public SqlEnumProvider(config : TypeProviderConfig) as this =
                     |> Seq.map getValueType
                 
                 let tupleType = tupleItemTypes |> Seq.toArray |> FSharpType.MakeTupleType
-                let getValue = fun (values : obj[]) -> box values, (values, tupleItemTypes) ||> Seq.zip |> Seq.skip 1 |> Seq.map Expr.Value |> Seq.toList |> Expr.NewTuple
-                
+                let getValue (values : obj[]) =
+                    let boxedValues = box values
+                    let tupleExpression = 
+                        (values |> Seq.skip 1, tupleItemTypes) 
+                        ||> Seq.zip 
+                        |> Seq.map Expr.Value 
+                        |> Seq.toList 
+                        |> Expr.NewTuple
+                    boxedValues, tupleExpression
                 tupleType, getValue
 
         let names, values = 


### PR DESCRIPTION
In SqlEnumProvider.fs when the query returns more than 2 columns, getValue was skipping first value AND first type in the tuple type definition, it should only skip first value but keep the type definition intact.

Added a basic test checking provided type exposes correct values.

I intend to use the feature soon, I would appreciate if we could have an updated nuget package for testing.