### PR TITLE
Expose an additional Table type when ResultType.DataTable is used

### DIFF
--- a/docs/content/output.fsx
+++ b/docs/content/output.fsx
@@ -113,6 +113,14 @@ let table = (new QueryPersonInfoSingletoneDataTable()).AsyncExecute(PersonId = 2
 for row in table.Rows do
     printfn "Person info:Id - %i,FirstName - %O,LastName - %O" row.PersonID row.FirstName row.LastName 
 
+// you can refer to the table type
+let table2 : QueryPersonInfoSingletoneDataTable.Table = (new QueryPersonInfoSingletoneDataTable()).Execute(PersonId = 2)
+
+// you can refer to the row type
+for row : QueryPersonInfoSingletoneDataTable.Table.Row in table2.Rows do
+  printfn "Person info:Id - %i,FirstName - %O,LastName - %O" row.PersonID row.FirstName row.LastName 
+
+
 (**
 
  * Same as previous but using `SqlProgrammabilityProvider<...>`

--- a/docs/content/output.fsx
+++ b/docs/content/output.fsx
@@ -118,7 +118,7 @@ let table2 : QueryPersonInfoSingletoneDataTable.Table = (new QueryPersonInfoSing
 
 // you can refer to the row type
 for row : QueryPersonInfoSingletoneDataTable.Table.Row in table2.Rows do
-  printfn "Person info:Id - %i,FirstName - %O,LastName - %O" row.PersonID row.FirstName row.LastName 
+    printfn "Person info:Id - %i,FirstName - %O,LastName - %O" row.PersonID row.FirstName row.LastName 
 
 
 (**

--- a/src/SqlClient.Tests/DataTablesTests.fs
+++ b/src/SqlClient.Tests/DataTablesTests.fs
@@ -273,10 +273,11 @@ type DataTablesTests() =
 
     [<Fact>]
     member __.``Can use Table type when ResultType = ResultType.DataTable`` () =
-      let t : GetArbitraryDataAsDataTable.Table = (new GetArbitraryDataAsDataTable()).Execute()
-      for (r: GetArbitraryDataAsDataTable.Table.Row) in t.Rows do
-        ()
-      Assert.NotNull(t)
-      Assert.Equal(1, t.Rows.[0].a)
-      Assert.Equal(2, t.Rows.[0].b)
-      Assert.Equal(3, t.Rows.[0].c)
+        let t : GetArbitraryDataAsDataTable.Table = (new GetArbitraryDataAsDataTable()).Execute()
+        for (r: GetArbitraryDataAsDataTable.Table.Row) in t.Rows do
+            ()
+
+        Assert.NotNull(t)
+        Assert.Equal(1, t.Rows.[0].a)
+        Assert.Equal(2, t.Rows.[0].b)
+        Assert.Equal(3, t.Rows.[0].c)

--- a/src/SqlClient.Tests/DataTablesTests.fs
+++ b/src/SqlClient.Tests/DataTablesTests.fs
@@ -9,7 +9,8 @@ open FSharp.Data
 open FSharp.Data.SqlClient
 open Xunit
 
-type AdventureWorks = SqlProgrammabilityProvider<ConnectionStrings.AdventureWorksNamed>
+open ProgrammabilityTest
+
 //Tables types structured as: [TypeAlias].[Namespace].Tables.[TableName]
 type ShiftTable = AdventureWorks.HumanResources.Tables.Shift
 type ProductCostHistory = AdventureWorks.Production.Tables.ProductCostHistory
@@ -273,6 +274,8 @@ type DataTablesTests() =
     [<Fact>]
     member __.``Can use Table type when ResultType = ResultType.DataTable`` () =
       let t : GetArbitraryDataAsDataTable.Table = (new GetArbitraryDataAsDataTable()).Execute()
+      for (r: GetArbitraryDataAsDataTable.Table.Row) in t.Rows do
+        ()
       Assert.NotNull(t)
       Assert.Equal(1, t.Rows.[0].a)
       Assert.Equal(2, t.Rows.[0].b)

--- a/src/SqlClient.Tests/DataTablesTests.fs
+++ b/src/SqlClient.Tests/DataTablesTests.fs
@@ -9,15 +9,14 @@ open FSharp.Data
 open FSharp.Data.SqlClient
 open Xunit
 
-open ProgrammabilityTest
-
+type AdventureWorks = SqlProgrammabilityProvider<ConnectionStrings.AdventureWorksNamed>
 //Tables types structured as: [TypeAlias].[Namespace].Tables.[TableName]
 type ShiftTable = AdventureWorks.HumanResources.Tables.Shift
 type ProductCostHistory = AdventureWorks.Production.Tables.ProductCostHistory
 
 type GetRowCount = SqlCommandProvider<"SELECT COUNT(*) FROM HumanResources.Shift", ConnectionStrings.AdventureWorksNamed, SingleRow = true>
 type GetShiftTableData = SqlCommandProvider<"SELECT * FROM HumanResources.Shift", ConnectionStrings.AdventureWorksNamed, ResultType.DataReader>
-
+type GetArbitraryDataAsDataTable = SqlCommandProvider<"select 1 a, 2 b, 3 c", ConnectionStrings.AdventureWorksNamed, ResultType.DataTable>
 type DataTablesTests() = 
 
     do
@@ -270,3 +269,11 @@ type DataTablesTests() =
         let t = new AdventureWorks.dbo.Tables.TableHavingColumnNamesWithSpaces()
         t.AddRow()
         Assert.Equal(1, t.Update())
+
+    [<Fact>]
+    member __.``Can use Table type when ResultType = ResultType.DataTable`` () =
+      let t : GetArbitraryDataAsDataTable.Table = (new GetArbitraryDataAsDataTable()).Execute()
+      Assert.NotNull(t)
+      Assert.Equal(1, t.Rows.[0].a)
+      Assert.Equal(2, t.Rows.[0].b)
+      Assert.Equal(3, t.Rows.[0].c)

--- a/src/SqlClient/DesignTime.fs
+++ b/src/SqlClient/DesignTime.fs
@@ -150,7 +150,7 @@ type DesignTime private() =
         recordType.AddMember ctor
         
         recordType    
-
+    
     static member internal GetDataRowType (columns: Column list) = 
         let rowType = ProvidedTypeDefinition("Row", Some typeof<DataRow>)
 
@@ -175,6 +175,11 @@ type DesignTime private() =
 
         rowType
 
+    static member internal GetDataTableType dataRowType =
+      let tableType = ProvidedTypeBuilder.MakeGenericType(typedefof<_ DataTable>, [ dataRowType ])
+      let tableProvidedType = ProvidedTypeDefinition("Table", Some tableType)
+      tableProvidedType
+
     static member internal GetOutputTypes (outputColumns: Column list, resultType, rank: ResultRank, hasOutputParameters) =    
         if resultType = ResultType.DataReader 
         then 
@@ -185,9 +190,9 @@ type DesignTime private() =
         elif resultType = ResultType.DataTable 
         then
             let dataRowType = DesignTime.GetDataRowType outputColumns
-
+            let dataTableType = DesignTime.GetDataTableType dataRowType 
             {
-                ProvidedType = ProvidedTypeBuilder.MakeGenericType(typedefof<_ DataTable>, [ dataRowType ])
+                ProvidedType = dataTableType
                 ErasedToType = typeof<DataTable<DataRow>>
                 ProvidedRowType = Some dataRowType
                 ErasedToRowType = typeof<Void>
@@ -226,7 +231,6 @@ type DesignTime private() =
 
                     let tupleTypeName = tupleType.PartialAssemblyQualifiedName
                     None, tupleType, <@@ Microsoft.FSharp.Reflection.FSharpValue.PreComputeTupleConstructor (Type.GetType (tupleTypeName))  @@>
-                    //None, tupleType, <@@ fun values -> Type.GetType(tupleTypeName, throwOnError = true).GetConstructors().[0].Invoke(values) @@>
             
             let nullsToOptions = QuotationsFactory.MapArrayNullableItems(outputColumns, "MapArrayObjItemToOption") 
             let combineWithNullsToOptions = typeof<QuotationsFactory>.GetMethod("GetMapperWithNullsToOptions") 
@@ -241,7 +245,7 @@ type DesignTime private() =
                     Some( typedefof<_ option>), typedefof<_ option>.MakeGenericType([| erasedToRowType |])
                 else //ResultRank.ScalarValue
                     None, erasedToRowType
-                          
+
             {
                 ProvidedType = 
                     if providedRowType.IsSome && genericOutputType.IsSome

--- a/src/SqlClient/DesignTime.fs
+++ b/src/SqlClient/DesignTime.fs
@@ -191,6 +191,10 @@ type DesignTime private() =
         then
             let dataRowType = DesignTime.GetDataRowType outputColumns
             let dataTableType = DesignTime.GetDataTableType dataRowType 
+            
+            // add .Row to .Table
+            dataTableType.AddMember dataRowType
+
             {
                 ProvidedType = dataTableType
                 ErasedToType = typeof<DataTable<DataRow>>

--- a/src/SqlClient/DesignTime.fs
+++ b/src/SqlClient/DesignTime.fs
@@ -150,7 +150,7 @@ type DesignTime private() =
         recordType.AddMember ctor
         
         recordType    
-    
+
     static member internal GetDataRowType (columns: Column list) = 
         let rowType = ProvidedTypeDefinition("Row", Some typeof<DataRow>)
 
@@ -176,9 +176,9 @@ type DesignTime private() =
         rowType
 
     static member internal GetDataTableType dataRowType =
-      let tableType = ProvidedTypeBuilder.MakeGenericType(typedefof<_ DataTable>, [ dataRowType ])
-      let tableProvidedType = ProvidedTypeDefinition("Table", Some tableType)
-      tableProvidedType
+        let tableType = ProvidedTypeBuilder.MakeGenericType(typedefof<_ DataTable>, [ dataRowType ])
+        let tableProvidedType = ProvidedTypeDefinition("Table", Some tableType)
+        tableProvidedType
 
     static member internal GetOutputTypes (outputColumns: Column list, resultType, rank: ResultRank, hasOutputParameters) =    
         if resultType = ResultType.DataReader 

--- a/src/SqlClient/SqlClientProvider.fs
+++ b/src/SqlClient/SqlClientProvider.fs
@@ -540,7 +540,12 @@ type public SqlProgrammabilityProvider(config : TypeProviderConfig) as this =
                         addRedirectToISqlCommandMethod typeof<string> "ToTraceString" 
 
                     commands.AddMember cmdProvidedType
-                    output.ProvidedRowType |> Option.iter cmdProvidedType.AddMember
+                    if resultType = ResultType.DataTable then
+                        // if we don't do this, we get a compile error
+                        // Error The type provider 'FSharp.Data.SqlProgrammabilityProvider' reported an error: type 'Table' was not added as a member to a declaring type <type instanciation name> 
+                        output.ProvidedType |> cmdProvidedType.AddMember
+                    else
+                        output.ProvidedRowType |> Option.iter cmdProvidedType.AddMember
 
                     let designTimeConfig = 
                         let expectedDataReaderColumns = 

--- a/src/SqlClient/SqlCommandProvider.fs
+++ b/src/SqlClient/SqlCommandProvider.fs
@@ -141,11 +141,11 @@ type public SqlCommandProvider(config : TypeProviderConfig) as this =
         do  
             cmdProvidedType.AddMember(ProvidedProperty("ConnectionStringOrName", typeof<string>, [], IsStatic = true, GetterCode = fun _ -> <@@ connectionStringOrName @@>))
 
-        do  
-            //for ResultType.Record and ResultType.DataTable
-            output.ProvidedRowType |> Option.iter cmdProvidedType.AddMember
-            
-            if resultType = ResultType.DataTable then
+        do
+            if resultType = ResultType.Records then
+                // Add .Record
+                output.ProvidedRowType |> Option.iter cmdProvidedType.AddMember
+            elif resultType = ResultType.DataTable then
                 // add .Table
                 output.ProvidedType |>  cmdProvidedType.AddMember
 

--- a/src/SqlClient/SqlCommandProvider.fs
+++ b/src/SqlClient/SqlCommandProvider.fs
@@ -141,8 +141,13 @@ type public SqlCommandProvider(config : TypeProviderConfig) as this =
         do  
             cmdProvidedType.AddMember(ProvidedProperty("ConnectionStringOrName", typeof<string>, [], IsStatic = true, GetterCode = fun _ -> <@@ connectionStringOrName @@>))
 
-        do  //Record
+        do  
+            //for ResultType.Record and ResultType.DataTable
             output.ProvidedRowType |> Option.iter cmdProvidedType.AddMember
+            
+            if resultType = ResultType.DataTable then
+                // add .Table
+                output.ProvidedType |>  cmdProvidedType.AddMember
 
         do  //ctors
             let designTimeConfig = 


### PR DESCRIPTION
I think this is minimal firs step to get this feature done, I'm open for suggestions if you want me to address any concern.

I'd like to work on removing code duplication between `SqlProgrammabilityProvider` and `SqlCommandProvider` but I wonder if this is not already being done in V2 branch and I think this should be a separate PR.

Detail of actual changes to make the feature work:

* add DesignTime.GetDataTableType to encapsulate creation of Table type (might make the type name a parameter in later consolidation, see note)
* when ResultType.DataTable is used, add the ProvidedType (which was already of DataTable type) as a member to SqlCommandProvider provided type
* add a simple unit test which shows that we can specify the type explicitly (I've removed importing ProgrammabilityTest as it is only needed for a single SqlProgrammabilityProvider definition, better to not couple test modules too much)

Note: I've only changed SqlCommandProvider, but I noticed there is some code duplication already for the SqlClient provider itself in handling the DataRow and DataTable types.

#214