### PR TITLE
Expose DataColumn properties on DataColumnCollection

### DIFF
--- a/docs/content/data modification.fsx
+++ b/docs/content/data modification.fsx
@@ -134,6 +134,13 @@ let firstRow = currencyRates.Rows.[0]
 firstRow.AverageRate
 
 (**
+It is possible to get a reference to the DataColumn object
+*)
+
+let averageRateColumn = currencyRates.Columns.AverageRate
+
+
+(**
 The `AddRow` method adds a new row to a table. 
 
 <img src="img/AddRow.png"/>

--- a/docs/content/data modification.fsx
+++ b/docs/content/data modification.fsx
@@ -29,7 +29,7 @@ do
         INSERT INTO Sales.CurrencyRate 
         VALUES (@currencyRateDate, @fromCurrencyCode, @toCurrencyCode, 
                 @averageRate, @endOfDayRate, DEFAULT) 
-    ", connectionString>()
+    ", connectionString>(connectionString)
 
     let recordsInserted = 
         cmd.Execute(
@@ -63,7 +63,7 @@ let businessEntityID, jobTitle, hireDate =
             HumanResources.Employee 
         WHERE 
             BusinessEntityID = @id
-        ", connectionString, ResultType.Tuples, SingleRow = true>()
+        ", connectionString, ResultType.Tuples, SingleRow = true>(connectionString))
 
     jamesKramerId |> cmd.Execute |> Option.get
 
@@ -72,7 +72,7 @@ assert("Production Technician - WC60" = jobTitle)
 let newJobTitle = "Uber " + jobTitle
 
 let recordsAffrected = 
-    use updatedJobTitle = new AdventureWorks.HumanResources.uspUpdateEmployeeHireInfo()
+    use updatedJobTitle = new AdventureWorks.HumanResources.uspUpdateEmployeeHireInfo(connectionString))
     updatedJobTitle.Execute(
         businessEntityID, 
         newJobTitle, 
@@ -88,7 +88,7 @@ assert(recordsAffrected = 1)
 let updatedJobTitle = 
     // Static Create factory method provides better IntelliSense than ctor.
     // See https://github.com/Microsoft/visualfsharp/issues/449
-    use cmd = new AdventureWorks.dbo.ufnGetContactInformation()
+    use cmd = new AdventureWorks.dbo.ufnGetContactInformation(connectionString)
 
     //Use ExecuteSingle if you're sure it return 0 or 1 rows.
     let result = cmd.ExecuteSingle(PersonID = jamesKramerId) 
@@ -217,7 +217,7 @@ do
         WHERE FromCurrencyCode = @from
             AND ToCurrencyCode = @to
             AND CurrencyRateDate > @date
-        ", connectionString, ResultType.DataReader>()
+        ", connectionString, ResultType.DataReader>(connectionString)
     //ResultType.DataReader !!!
     let currencyRates = new AdventureWorks.Sales.Tables.CurrencyRate()
     //load data into data table
@@ -354,7 +354,7 @@ do
         WHERE FromCurrencyCode = @from
             AND ToCurrencyCode = @to
             AND CurrencyRateDate > @date
-        ", connectionString, ResultType.DataTable>()
+        ", connectionString, ResultType.DataTable>(connectionString)
     //ResultType.DataTable !!!
     let currencyRates = cmd.Execute("USD", "GBP", DateTime(2014, 1, 1)) 
 

--- a/src/SqlClient.Tests/DataTablesTests.fs
+++ b/src/SqlClient.Tests/DataTablesTests.fs
@@ -325,4 +325,39 @@ type DataTablesTests() =
         Assert.Equal(r.c, 108)
         Assert.Equal(r.d, Some 108)
 
+    [<Fact>]
+    member __.``Can use DataColumnCollection`` () =
 
+        let table = (new GetArbitraryDataAsDataTable()).Execute()
+
+        let columnCollection : System.Data.DataColumnCollection =
+            // this is more involved than just doing table.Columns because
+            // DataColumnCollection is a sealed class, and the generative TP
+            // attaches properties to a fake inherited type
+            // In order to get a real DataColumnCollection, just use the table
+            // as a normal DataTable.
+            let table : System.Data.DataTable = table :> _
+            table.Columns
+        Assert.Equal(table.Columns.Count, columnCollection.Count)
+    
+    [<Fact>]
+    member __.``Can use datacolumns on SqlProgrammabilityProvider`` () =
+        let products = AdventureWorks.Production.Tables.Product()
+        
+        let product = products.NewRow()
+        
+        // can use SetValue
+        let newName = "foo"
+        products.Columns.Name.SetValue(product, newName)
+        Assert.True(product.Name = newName)
+
+        // use as plain DataColumns
+        let name = product.[products.Columns.Name] :?> string
+        Assert.True(product.Name = name)
+
+        // can use GetValue
+        product.FinishedGoodsFlag <- true
+        let finishedGoodsFlag = products.Columns.FinishedGoodsFlag.GetValue(product)
+        Assert.Equal(product.FinishedGoodsFlag, finishedGoodsFlag)
+
+        

--- a/src/SqlClient.Tests/DataTablesTests.fs
+++ b/src/SqlClient.Tests/DataTablesTests.fs
@@ -294,36 +294,6 @@ type DataTablesTests() =
         // getting value same way as a plain datatable still yields DBNull
         Assert.Equal(DBNull.Value, r.[t.Columns.d] :?> DBNull)
 
-    [<Fact>]
-    member __.``Can use datacolumns GetValue and SetValue methods`` () =
-        let t = (new GetArbitraryDataAsDataTable()).Execute()
-        let r = t.Rows.[0]
-        let a, b, c, d =
-          t.Columns.a.GetValue(r)
-          , t.Columns.b.GetValue(r)
-          , t.Columns.c.GetValue(r)
-          , t.Columns.d.GetValue(r)
-
-        Assert.Equal(r.a, a)
-        Assert.Equal(r.b, b)
-        Assert.Equal(r.c, c)
-        Assert.Equal(r.d, d)
-
-        // need to make column readonly = false in order to use SetValue from the DataColumn
-        t.Columns.a.ReadOnly <- false
-        t.Columns.b.ReadOnly <- false
-        t.Columns.c.ReadOnly <- false
-        t.Columns.d.ReadOnly <- false
-
-        t.Columns.a.SetValue(r, 108)
-        t.Columns.b.SetValue(r, 108)
-        t.Columns.c.SetValue(r, 108)
-        t.Columns.d.SetValue(r, Some 108)
-
-        Assert.Equal(r.a, 108)
-        Assert.Equal(r.b, 108)
-        Assert.Equal(r.c, 108)
-        Assert.Equal(r.d, Some 108)
 
     [<Fact>]
     member __.``Can use DataColumnCollection`` () =
@@ -345,19 +315,8 @@ type DataTablesTests() =
         let products = AdventureWorks.Production.Tables.Product()
         
         let product = products.NewRow()
-        
-        // can use SetValue
-        let newName = "foo"
-        products.Columns.Name.SetValue(product, newName)
-        Assert.True(product.Name = newName)
+        product.Name <- "foo"
 
         // use as plain DataColumns
         let name = product.[products.Columns.Name] :?> string
         Assert.True(product.Name = name)
-
-        // can use GetValue
-        product.FinishedGoodsFlag <- true
-        let finishedGoodsFlag = products.Columns.FinishedGoodsFlag.GetValue(product)
-        Assert.Equal(product.FinishedGoodsFlag, finishedGoodsFlag)
-
-        

--- a/src/SqlClient.Tests/DataTablesTests.fs
+++ b/src/SqlClient.Tests/DataTablesTests.fs
@@ -294,3 +294,35 @@ type DataTablesTests() =
         // getting value same way as a plain datatable still yields DBNull
         Assert.Equal(DBNull.Value, r.[t.Columns.d] :?> DBNull)
 
+    [<Fact>]
+    member __.``Can use datacolumns GetValue and SetValue methods`` () =
+        let t = (new GetArbitraryDataAsDataTable()).Execute()
+        let r = t.Rows.[0]
+        let a, b, c, d =
+          t.Columns.a.GetValue(r)
+          , t.Columns.b.GetValue(r)
+          , t.Columns.c.GetValue(r)
+          , t.Columns.d.GetValue(r)
+
+        Assert.Equal(r.a, a)
+        Assert.Equal(r.b, b)
+        Assert.Equal(r.c, c)
+        Assert.Equal(r.d, d)
+
+        // need to make column readonly = false in order to use SetValue from the DataColumn
+        t.Columns.a.ReadOnly <- false
+        t.Columns.b.ReadOnly <- false
+        t.Columns.c.ReadOnly <- false
+        t.Columns.d.ReadOnly <- false
+
+        t.Columns.a.SetValue(r, 108)
+        t.Columns.b.SetValue(r, 108)
+        t.Columns.c.SetValue(r, 108)
+        t.Columns.d.SetValue(r, Some 108)
+
+        Assert.Equal(r.a, 108)
+        Assert.Equal(r.b, 108)
+        Assert.Equal(r.c, 108)
+        Assert.Equal(r.d, Some 108)
+
+

--- a/src/SqlClient/DesignTime.fs
+++ b/src/SqlClient/DesignTime.fs
@@ -185,11 +185,18 @@ type DesignTime private() =
 
         rowType
 
-    static member internal GetDataTableType dataRowType (outputColumns: Column list) =
+    static member internal GetDataTableType typeName dataRowType (outputColumns: Column list) =
         let tableType = ProvidedTypeBuilder.MakeGenericType(typedefof<_ DataTable>, [ dataRowType ])
-        let tableProvidedType = ProvidedTypeDefinition("Table", Some tableType)
+        let tableProvidedType = ProvidedTypeDefinition(typeName, Some tableType)
       
         let columnsType = ProvidedTypeDefinition("Columns", Some typeof<DataColumnCollection>)
+        
+        let ctor = ProvidedConstructor([])
+        ctor.InvokeCode <- fun args ->
+          <@@
+            ()
+          @@>
+        columnsType.AddMember ctor
         let columnsProperty = ProvidedProperty("Columns", columnsType)
         tableProvidedType.AddMember columnsType
         
@@ -262,7 +269,7 @@ type DesignTime private() =
         elif resultType = ResultType.DataTable 
         then
             let dataRowType = DesignTime.GetDataRowType outputColumns
-            let dataTableType = DesignTime.GetDataTableType dataRowType outputColumns
+            let dataTableType = DesignTime.GetDataTableType "Table" dataRowType outputColumns
             
             // add .Row to .Table
             dataTableType.AddMember dataRowType

--- a/src/SqlClient/DesignTime.fs
+++ b/src/SqlClient/DesignTime.fs
@@ -158,8 +158,8 @@ type DesignTime private() =
             let setter = QuotationsFactory.GetBody("SetNullableValueInDataRow", column.TypeInfo.ClrType, name)
             getter, setter
         else
-            let getter = fun (args: _ list) -> <@@ (%%args.[0] : DataRow).[name] @@>
-            let setter = fun (args: _ list) -> <@@ (%%args.[0] : DataRow).[name] <- %%Expr.Coerce(args.[1], typeof<obj>) @@>
+            let getter = QuotationsFactory.GetBody("GetNonNullableValueFromDataRow", column.TypeInfo.ClrType, name)
+            let setter = QuotationsFactory.GetBody("SetNonNullableValueInDataRow", column.TypeInfo.ClrType, name)
             getter, setter
 
     static member internal GetDataRowType (columns: Column list) = 
@@ -175,6 +175,8 @@ type DesignTime private() =
             let property = ProvidedProperty(col.Name, propertyType, GetterCode = getter)
 
             if not col.ReadOnly then
+              // only expose a setter if the column is not readonly
+              // note: if this is an issue, we always expose a SetValue method on the typed DataColumn itself
               property.SetterCode <- setter
             
             property

--- a/src/SqlClient/DesignTime.fs
+++ b/src/SqlClient/DesignTime.fs
@@ -222,38 +222,6 @@ type DesignTime private() =
                         column
                     @@>
 
-            let getValueMethod =
-                ProvidedMethod(
-                    "GetValue"
-                    , [ProvidedParameter("row", dataRowType)]
-                    , column.ClrTypeConsideringNullable
-                )
-        
-            let getter, setter = DesignTime.GetDataRowPropertyGetterAndSetterCode(column)
-
-            getValueMethod.InvokeCode <- 
-                fun args -> 
-                    // we don't care of args.[0] (the DataColumn) because getter code is already made for that column
-                    getter args.Tail
-           
-            let setValueMethod =
-                ProvidedMethod(
-                    "SetValue"
-                    , [
-                        ProvidedParameter("row", dataRowType)
-                        ProvidedParameter("value", column.ClrTypeConsideringNullable)
-                    ]
-                    , typeof<unit>
-                )
-        
-            setValueMethod.InvokeCode <-
-                fun args ->
-                    // we don't care of args.[0] (the DataColumn) because setter code is already made for that column
-                    setter args.Tail
-
-            propertyType.AddMember getValueMethod
-            propertyType.AddMember setValueMethod
-
             columnsType.AddMember property
             columnsType.AddMember propertyType
 

--- a/src/SqlClient/QuotationsFactory.fs
+++ b/src/SqlClient/QuotationsFactory.fs
@@ -120,3 +120,9 @@ type QuotationsFactory private() =
         fun values -> 
             nullsToOptions values
             mapper values
+
+    static member private GetNonNullableValueFromDataRow<'T>(exprArgs : Expr list, name: string) =
+        <@ (%%exprArgs.[0] : DataRow).[name] @>
+
+    static member private SetNonNullableValueInDataRow<'T>(exprArgs : Expr list, name : string) =
+        <@ (%%exprArgs.[0] : DataRow).[name] <- %%Expr.Coerce(exprArgs.[1], typeof<obj>) @>

--- a/src/SqlClient/SqlClientProvider.fs
+++ b/src/SqlClient/SqlClientProvider.fs
@@ -304,8 +304,8 @@ type public SqlProgrammabilityProvider(config : TypeProviderConfig) as this =
                             //remove from PK if default value provided by DB on insert.
                         else c
                     )
-                    |> Seq.toArray
-
+                    |> Seq.toList
+                
 
                 //type data row
                 let dataRowType = ProvidedTypeDefinition("Row", Some typeof<DataRow>)
@@ -349,7 +349,7 @@ type public SqlProgrammabilityProvider(config : TypeProviderConfig) as this =
                         dataRowType.AddMember property
 
                 //type data table
-                let dataTableType = ProvidedTypeDefinition(tableName, baseType = Some( typedefof<_ DataTable>.MakeGenericType(dataRowType)))
+                let dataTableType = DesignTime.GetDataTableType tableName dataRowType columns
                 tagProvidedType dataTableType
                 dataTableType.AddMember dataRowType
         
@@ -361,7 +361,7 @@ type public SqlProgrammabilityProvider(config : TypeProviderConfig) as this =
                     ctor.InvokeCode <- fun _ -> 
                         let serializedSchema = 
                             columns 
-                            |> Array.map (fun x ->
+                            |> List.map (fun x ->
                                 let nullable = x.Nullable || x.HasDefaultConstraint
                                 sprintf "%s\t%s\t%b\t%i\t%b\t%b\t%b" 
                                     x.Name x.TypeInfo.ClrTypeFullName nullable x.MaxLength x.ReadOnly x.Identity x.PartOfUniqueKey                                 


### PR DESCRIPTION
### Expose DataColumn properties on DataTable instances for SqlCommandProvider<..., ResultType.DataTable>

for each column of the result set, a get property named after the column name is attached to `DataTable.Columns`:

```fsharp
let table = Command.Execute()
let column1 : System.Data.DataColumn = table.Columns.column1
```

Edit: the part bellow not part of this PR anymore:

### Expose value getter and setter on the provided data columns

```fsharp
member this.GetValue (row: DataRowType) : ColumnType
member this.SetValue (row: DataRowType) (value: ColumnType) : unit
```

```fsharp
let value : int = column1.GetValue(table.Rows.[0])
column1.ReadOnly <- false
column1.SetValue(table.Rows.[0], value + 1)
```