### PR TITLE
Expose custom getter/setter methods on provided DataColumn properties

### DIFF
--- a/src/SqlClient.Tests/DataTablesTests.fs
+++ b/src/SqlClient.Tests/DataTablesTests.fs
@@ -296,6 +296,36 @@ type DataTablesTests() =
         // getting value same way as a plain datatable still yields DBNull
         Assert.Equal(DBNull.Value, r.[t.Columns.d] :?> DBNull)
 
+    [<Fact>]
+    member __.``Can use datacolumns GetValue and SetValue methods`` () =
+        let t = (new GetArbitraryDataAsDataTable()).Execute()
+        let r = t.Rows.[0]
+        let a, b, c, d =
+          t.Columns.a.GetValue(r)
+          , t.Columns.b.GetValue(r)
+          , t.Columns.c.GetValue(r)
+          , t.Columns.d.GetValue(r)
+
+        Assert.Equal(r.a, a)
+        Assert.Equal(r.b, b)
+        Assert.Equal(r.c, c)
+        Assert.Equal(r.d, d)
+
+        // need to make column readonly = false in order to use SetValue from the DataColumn
+        t.Columns.a.ReadOnly <- false
+        t.Columns.b.ReadOnly <- false
+        t.Columns.c.ReadOnly <- false
+        t.Columns.d.ReadOnly <- false
+
+        t.Columns.a.SetValue(r, 108)
+        t.Columns.b.SetValue(r, 108)
+        t.Columns.c.SetValue(r, 108)
+        t.Columns.d.SetValue(r, Some 108)
+
+        Assert.Equal(r.a, 108)
+        Assert.Equal(r.b, 108)
+        Assert.Equal(r.c, 108)
+        Assert.Equal(r.d, Some 108)
 
     [<Fact>]
     member __.``Can use DataColumnCollection`` () =
@@ -317,12 +347,21 @@ type DataTablesTests() =
         let products = new AdventureWorks.Production.Tables.Product()
         
         let product = products.NewRow()
-        product.Name <- "foo"
+        
+        // can use SetValue
+        let newName = "foo"
+        products.Columns.Name.SetValue(product, newName)
+        Assert.True(product.Name = newName)
 
         // use as plain DataColumns
         let name = product.[products.Columns.Name] :?> string
         Assert.True(product.Name = name)
-    
+
+        // can use GetValue
+        product.FinishedGoodsFlag <- true
+        let finishedGoodsFlag = products.Columns.FinishedGoodsFlag.GetValue(product)
+        Assert.Equal(product.FinishedGoodsFlag, finishedGoodsFlag)
+
     [<Fact>]
     member __.``Can use Table property on SqlCommandProvider's rows`` () =
         use cmd = new GetArbitraryDataAsDataTable()

--- a/src/SqlClient/DesignTime.fs
+++ b/src/SqlClient/DesignTime.fs
@@ -216,6 +216,38 @@ type DesignTime private() =
                         columns.[columnName]
                     @@>
 
+            let getValueMethod =
+                ProvidedMethod(
+                    "GetValue"
+                    , [ProvidedParameter("row", dataRowType)]
+                    , column.ErasedToType
+                )
+        
+            let getter, setter = DesignTime.GetDataRowPropertyGetterAndSetterCode(column)
+
+            getValueMethod.InvokeCode <- 
+                fun args -> 
+                    // we don't care of args.[0] (the DataColumn) because getter code is already made for that column
+                    getter args.Tail
+           
+            let setValueMethod =
+                ProvidedMethod(
+                    "SetValue"
+                    , [
+                        ProvidedParameter("row", dataRowType)
+                        ProvidedParameter("value", column.ErasedToType)
+                    ]
+                    , typeof<unit>
+                )
+        
+            setValueMethod.InvokeCode <-
+                fun args ->
+                    // we don't care of args.[0] (the DataColumn) because setter code is already made for that column
+                    setter args.Tail
+
+            propertyType.AddMember getValueMethod
+            propertyType.AddMember setValueMethod
+
             columnsType.AddMember property
             columnsType.AddMember propertyType
 


### PR DESCRIPTION
This PR provides those members which were discussed in #215

``` fsharp
member this.GetValue (row: DataRowType) : ColumnType
member this.SetValue (row: DataRowType) (value: ColumnType) : unit
```

allowing such code as shown bellow; useful when the column is coming from an expression in the SQL which makes that there is no setter on provided properties.

``` fsharp
let value : int = column1.GetValue(table.Rows.[0])
column1.ReadOnly <- false
column1.SetValue(table.Rows.[0], value + 1)
```
