### PR TITLE
Convenience DataRow.Table property should point to typed table

### DIFF
--- a/src/SqlClient.Tests/DataTablesTests.fs
+++ b/src/SqlClient.Tests/DataTablesTests.fs
@@ -321,3 +321,21 @@ type DataTablesTests() =
         // use as plain DataColumns
         let name = product.[products.Columns.Name] :?> string
         Assert.True(product.Name = name)
+    
+    [<Fact>]
+    member __.``Can use Table property on SqlCommandProvider's rows`` () =
+        let t = (new GetArbitraryDataAsDataTable()).Execute()
+        let r = t.Rows.[0]
+        Assert.True(r.Table = t)
+        Assert.True(r.Table.Columns.a = t.Columns.a)
+
+    [<Fact>]
+    member __.``Can use Table property on SqlProgrammabilityProvider's rows`` () =
+        let products = new AdventureWorks.Production.Tables.Product()
+        
+        let product = products.NewRow()
+        product.Name <- "foo"
+        
+        // can access typed table from row
+        let name = product.[product.Table.Columns.Name] :?> string
+        Assert.True(product.Name = name)

--- a/src/SqlClient/DesignTime.fs
+++ b/src/SqlClient/DesignTime.fs
@@ -217,6 +217,21 @@ type DesignTime private() =
 
         tableProvidedType
 
+    static member internal SetupTableProperty(rowType: ProvidedTypeDefinition) (tableType: ProvidedTypeDefinition) =
+        let tableProperty =
+            ProvidedProperty(
+                "Table"
+                , tableType
+                , GetterCode = 
+                    fun args ->
+                        <@@
+                            let row : DataRow = %%args.[0]
+                            let table = row.Table
+                            table
+                        @@>
+            )
+        rowType.AddMember tableProperty
+
     static member internal GetOutputTypes (outputColumns: Column list, resultType, rank: ResultRank, hasOutputParameters) =    
         if resultType = ResultType.DataReader 
         then 
@@ -228,7 +243,7 @@ type DesignTime private() =
         then
             let dataRowType = DesignTime.GetDataRowType outputColumns
             let dataTableType = DesignTime.GetDataTableType "Table" dataRowType outputColumns
-            
+            DesignTime.SetupTableProperty dataRowType dataTableType
             // add .Row to .Table
             dataTableType.AddMember dataRowType
 

--- a/src/SqlClient/SqlClientProvider.fs
+++ b/src/SqlClient/SqlClientProvider.fs
@@ -350,6 +350,7 @@ type public SqlProgrammabilityProvider(config : TypeProviderConfig) as this =
 
                 //type data table
                 let dataTableType = DesignTime.GetDataTableType tableName dataRowType columns
+                DesignTime.SetupTableProperty dataRowType dataTableType
                 tagProvidedType dataTableType
                 dataTableType.AddMember dataRowType
         


### PR DESCRIPTION
Allow to recover typed datatable from typed datarow instance via `.Table` property.