### PR TITLE
upgrade tsql parser version

### DIFF
--- a/src/SqlClient.Tests/SqlClient.Tests.NET40/App.config
+++ b/src/SqlClient.Tests/SqlClient.Tests.NET40/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
+</configuration>

--- a/src/SqlClient.Tests/SqlClient.Tests.NET40/App.config
+++ b/src/SqlClient.Tests/SqlClient.Tests.NET40/App.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
-  </startup>
-</configuration>

--- a/src/SqlClient.Tests/SqlClient.Tests.NET40/SqlClient.Tests.NET40.fsproj
+++ b/src/SqlClient.Tests/SqlClient.Tests.NET40/SqlClient.Tests.NET40.fsproj
@@ -9,9 +9,9 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>SqlClient.Tests.NET40</RootNamespace>
     <AssemblyName>SqlClient.Tests.NET40</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <Name>SqlClient.Tests.NET40</Name>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
@@ -65,9 +65,6 @@
   </Target>
   <ItemGroup>
     <Compile Include="Program.fs" />
-    <Content Include="App.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
     <Content Include="Uncomment.App.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SqlClient.Tests/SqlClient.Tests.NET40/SqlClient.Tests.NET40.fsproj
+++ b/src/SqlClient.Tests/SqlClient.Tests.NET40/SqlClient.Tests.NET40.fsproj
@@ -9,9 +9,9 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>SqlClient.Tests.NET40</RootNamespace>
     <AssemblyName>SqlClient.Tests.NET40</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
     <Name>SqlClient.Tests.NET40</Name>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
@@ -65,6 +65,9 @@
   </Target>
   <ItemGroup>
     <Compile Include="Program.fs" />
+    <Content Include="App.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Uncomment.App.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SqlClient/DesignTime.fs
+++ b/src/SqlClient/DesignTime.fs
@@ -468,7 +468,7 @@ type DesignTime private() =
         else
             None
 
-    static member internal CreateUDTT(t: TypeInfo) = 
+    static member internal CreateUDTT(t: FSharp.Data.SqlClient.Extensions.TypeInfo) = 
         assert(t.TableType)
         let rowType = ProvidedTypeDefinition(t.UdttName, Some typeof<obj>, HideObjectMethods = true)
 

--- a/src/SqlClient/DesignTime.fs
+++ b/src/SqlClient/DesignTime.fs
@@ -468,7 +468,7 @@ type DesignTime private() =
         else
             None
 
-    static member internal CreateUDTT(t: FSharp.Data.SqlClient.Extensions.TypeInfo) = 
+    static member internal CreateUDTT(t: TypeInfo) = 
         assert(t.TableType)
         let rowType = ProvidedTypeDefinition(t.UdttName, Some typeof<obj>, HideObjectMethods = true)
 

--- a/src/SqlClient/DesignTime.fs
+++ b/src/SqlClient/DesignTime.fs
@@ -392,7 +392,7 @@ type DesignTime private() =
     static member internal RewriteSqlStatementToEnableMoreThanOneParameterDeclaration(cmd: SqlCommand, why: SqlException) =  
         
         let getVariables tsql = 
-            let parser = Microsoft.SqlServer.TransactSql.ScriptDom.TSql120Parser( true)
+            let parser = Microsoft.SqlServer.TransactSql.ScriptDom.TSql140Parser( true)
             let tsqlReader = new System.IO.StringReader(tsql)
             let errors = ref Unchecked.defaultof<_>
             let fragment = parser.Parse(tsqlReader, errors)

--- a/src/SqlClient/SqlClient.fsproj
+++ b/src/SqlClient/SqlClient.fsproj
@@ -55,7 +55,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.SqlServer.TransactSql.ScriptDom">
-      <HintPath>..\..\lib\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.SqlServer.TransactSql.ScriptDom.14.0.3811.1\lib\net40\Microsoft.SqlServer.TransactSql.ScriptDom.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />

--- a/src/SqlClient/SqlClient.fsproj
+++ b/src/SqlClient/SqlClient.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>SqlCommandTypeProvider</RootNamespace>
     <AssemblyName>FSharp.Data.SqlClient</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <Name>SqlClient</Name>
     <TargetFrameworkProfile />
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>

--- a/src/SqlClient/SqlClient.fsproj
+++ b/src/SqlClient/SqlClient.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>SqlCommandTypeProvider</RootNamespace>
     <AssemblyName>FSharp.Data.SqlClient</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <Name>SqlClient</Name>
     <TargetFrameworkProfile />
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>

--- a/src/SqlClient/SqlClientExtensions.fs
+++ b/src/SqlClient/SqlClientExtensions.fs
@@ -403,7 +403,7 @@ type SqlConnection with
 
         let paramDefaults = Task.Factory.StartNew( fun() ->
 
-            let parser = Microsoft.SqlServer.TransactSql.ScriptDom.TSql120Parser( true)
+            let parser = Microsoft.SqlServer.TransactSql.ScriptDom.TSql140Parser( true)
             let tsqlReader = new StringReader(routine.Definition)
             let errors = ref Unchecked.defaultof<_>
             let fragment = parser.Parse(tsqlReader, errors)

--- a/src/SqlClient/packages.config
+++ b/src/SqlClient/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FSharp.TypeProviders.StarterPack" version="1.1.3.72" targetFramework="net40" />
+  <package id="Microsoft.SqlServer.TransactSql.ScriptDom" version="14.0.3811.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
support newer Sql Server T-Sql versions
For example queries with hints like : 

select * from Table
option ( use hint('enable_parallel_plan_preference'))