### PR TITLE
Compilation error on mono

### DIFF
--- a/src/SqlClient/DesignTime.fs
+++ b/src/SqlClient/DesignTime.fs
@@ -468,7 +468,7 @@ type DesignTime private() =
         else
             None
 
-    static member internal CreateUDTT(t: TypeInfo) = 
+    static member internal CreateUDTT(t: FSharp.Data.SqlClient.Extensions.TypeInfo) = 
         assert(t.TableType)
         let rowType = ProvidedTypeDefinition(t.UdttName, Some typeof<obj>, HideObjectMethods = true)
 

--- a/src/SqlClient/SqlClient.fsproj
+++ b/src/SqlClient/SqlClient.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>SqlCommandTypeProvider</RootNamespace>
     <AssemblyName>FSharp.Data.SqlClient</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <Name>SqlClient</Name>
     <TargetFrameworkProfile />
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>


### PR DESCRIPTION
- `IReadOnlyCollection` is not present on .net 4 on mono, however, for .net 4.5 it is
- `TypeInfo` is not resolved as the internal type, but as system `TypeInfo`, specifying the correct by being more explicit solves the issue on mono.