### PR TITLE
fix FAKE version

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,5 +1,5 @@
 @echo off
 if not exist packages\FAKE\tools\Fake.exe ( 
-  .nuget\nuget.exe install FAKE -OutputDirectory packages -Prerelease -ExcludeVersion 
+  .nuget\nuget.exe install FAKE -OutputDirectory packages -Prerelease -ExcludeVersion -Version 4.1.2
 )
 packages\FAKE\tools\FAKE.exe build.fsx %* 


### PR DESCRIPTION
Fixes the following issue: from clean working copy, run build.cmd, then get this error message:

```
Starting Target: RunTests (==> BuildTests)
C:\dev\projects\github.com\fsprojects\FSharp.Data.SqlClient2\tools\xUnit\xunit.console.clr4.exe "C:\dev\projects\github.com\fsprojects\FSharp.Data.SqlClient2\bin\SqlClient.Tests.dll" "/noshadow" "/xml" "C:\dev\projects\github.com\fsprojects\FSharp.Data.SqlClient2\bin\SqlClient.Tests.dll.xml" "/html" "C:\dev\projects\github.com\fsprojects\FSharp.Data.SqlClient2\bin\SqlClient.Tests.dll.html"
xUnit.net console test runner (64-bit .NET 4.0.30319.42000)
Copyright (C) 2013 Outercurve Foundation.
System.IO.FileLoadException: Could not load file or assembly 'FSharp.Core, Version=4.4.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)
File name: 'FSharp.Core, Version=4.4.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
   at System.ModuleHandle.ResolveType(RuntimeModule module, Int32 typeToken, IntPtr* typeInstArgs, Int32 typeInstCount, IntPtr* methodInstArgs, Int32 methodInstCount, ObjectHandleOnStack type)
   at System.ModuleHandle.ResolveTypeHandleInternal(RuntimeModule module, Int32 typeToken, RuntimeTypeHandle[] typeInstantiationContext, RuntimeTypeHandle[] methodInstantiationContext)
   at System.Reflection.RuntimeModule.ResolveType(Int32 metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
   at System.Reflection.CustomAttribute.FilterCustomAttributeRecord(CustomAttributeRecord caRecord, MetadataImport scope, Assembly& lastAptcaOkAssembly, RuntimeModule decoratedModule, MetadataToken decoratedToken, RuntimeType attributeFilterType, Boolean mustBeInheritable, Object[] attributes, IList derivedAttributes, RuntimeType& attributeType, IRuntimeMethodInfo& ctor, Boolean& ctorHasParameters, Boolean& isVarArg)
   at System.Reflection.CustomAttribute.IsCustomAttributeDefined(RuntimeModule decoratedModule, Int32 decoratedMetadataToken, RuntimeType attributeFilterType, Int32 attributeCtorToken, Boolean mustBeInheritable)
   at System.Reflection.CustomAttribute.IsDefined(RuntimeType type, RuntimeType caType, Boolean inherit)
   at Xunit.Sdk.TypeUtility.IsTestClass(ITypeInfo type)
   at Xunit.Sdk.TestClassCommandFactory.Make(ITypeInfo typeInfo)
   at Xunit.Sdk.Executor.EnumerateTests..ctor(Executor executor, Object _handler)
   at Xunit.ExecutorWrapper.RethrowWithNoStackTraceLoss(Exception ex)
   at Xunit.ExecutorWrapper.CreateObject(String typeName, Object[] args)
   at Xunit.ExecutorWrapper.EnumerateTests()
   at Xunit.TestAssemblyBuilder.Build(IExecutorWrapper executorWrapper)
   at Xunit.MultiAssemblyTestEnvironment.Load(IExecutorWrapper executorWrapper)
   at Xunit.ConsoleClient.Program.RunProject(XunitProject project, Boolean teamcity, Boolean silent)
   at Xunit.ConsoleClient.Program.Main(String[] args)

WRN: Assembly binding logging is turned OFF.
To enable assembly bind failure logging, set the registry value [HKLM\Software\Microsoft\Fusion!EnableLog] (DWORD) to 1.
Note: There is some performance penalty associated with assembly bind failure logging.
To turn this feature off, remove the registry value [HKLM\Software\Microsoft\Fusion!EnableLog].

Running build failed.
Error:
System.Exception: xUnit failed for the following assemblies: C:\dev\projects\github.com\fsprojects\FSharp.Data.SqlClient2\bin\SqlClient.Tests.dll
   at Fake.XUnitHelper.xUnit@143-1.Invoke(String message) in C:\proj\FAKE\src\legacy\FakeLib\UnitTest\XUnit\XUnitHelper.fs:line 143
   at Fake.XUnitHelper.xUnit(FSharpFunc`2 setParams, IEnumerable`1 assemblies) in C:\proj\FAKE\src\legacy\FakeLib\UnitTest\XUnit\XUnitHelper.fs:line 144
   at FSI_0005.Build.clo@152-15.Invoke(Unit _arg7) in C:\dev\projects\github.com\fsprojects\FSharp.Data.SqlClient2\build.fsx:line 153
   at Fake.TargetHelper.runSingleTarget(TargetTemplate`1 target) in C:\proj\FAKE\src\legacy\FakeLib\TargetHelper.fs:line 683
```