### PR TITLE
Enable typed data table constructor to initialize an empty datatable with the expected columns.

### DIFF
--- a/src/SqlClient.Tests/DataTablesTests.fs
+++ b/src/SqlClient.Tests/DataTablesTests.fs
@@ -407,3 +407,25 @@ type DataTablesTests() =
 
         Assert.Equal(1, rowsAffected)
     
+    [<Fact>]
+    member __.``can build arbitrary data table from inline sql``() =
+        use table = new SqlCommandProvider<"SELECT 1 a, 2 b", ConnectionStrings.AdventureWorksNamed, ResultType.DataTable>.Table()
+        let r = table.NewRow()
+        table.Columns.a.set_ReadOnly false
+        table.Columns.a.SetValue(r, 2)
+        Assert.Equal(r.a , 2)
+        
+    [<Fact>]
+    member __.``can build arbitrary table and columns exist``() =
+        let t = new GetArbitraryDataAsDataTable.Table()
+        let r = t.NewRow()
+        t.Columns.a.set_ReadOnly false
+        t.Columns.a.SetValue(r, 1)
+        Assert.Equal(r.a , 1)
+               
+    [<Fact>]
+    member __.``can't update on arbitrarilly constructed table``() =
+        let t = new GetArbitraryDataAsDataTable.Table()
+        let e = Assert.Throws(fun () -> t.Update() |> ignore)
+        Assert.Equal<string>("This command wasn't constructed from SqlProgrammabilityProvider, call to Update is not supported.", e.Message)
+       

--- a/src/SqlClient/DataTable.fs
+++ b/src/SqlClient/DataTable.fs
@@ -41,7 +41,11 @@ type DataTable<'T when 'T :> DataRow>(selectCommand: SqlCommand, ?connectionStri
     member private this.IsDirectTable = this.TableName <> null
     
     member this.Update(?connection, ?transaction, ?batchSize, ?continueUpdateOnError) = 
-        
+        // not supported on all DataTable instances
+        match selectCommand with
+        | null -> failwith "This command wasn't constructed from SqlProgrammabilityProvider, call to Update is not supported."
+        | _ -> ()
+
         connection |> Option.iter selectCommand.set_Connection
         transaction |> Option.iter selectCommand.set_Transaction 
         
@@ -88,6 +92,9 @@ type DataTable<'T when 'T :> DataRow>(selectCommand: SqlCommand, ?connectionStri
             | _, Some(t: SqlTransaction) -> t.Connection, t
             | Some c, None -> c, null
             | None, None ->
+                match selectCommand with
+                | null -> failwith "To issue BulkCopy on this table, you need to provide your own connection or transaction"
+                | _ -> ()
                 if this.IsDirectTable
                 then 
                     assert(connectionString.IsSome)


### PR DESCRIPTION
This addresses #228.

Regarding the constructor code quotation, I've tried to factorize the code within the quotation but had issues to make this compile or work at design time, I moved most of the constructor body into `setupTableFromSerializedColumns` function called from the quotation.