### PR TITLE
Fix exception when using TVP parameter with fixed length string

### DIFF
--- a/src/SqlClient.DesignTime/SqlClientExtensions.fs
+++ b/src/SqlClient.DesignTime/SqlClientExtensions.fs
@@ -106,12 +106,12 @@ let internal providerTypes =
         "time", (SqlDbType.Time, "System.TimeSpan", true)
 
         // character strings
-        "char", (SqlDbType.Char, "System.String", true)
+        "char", (SqlDbType.Char, "System.String", false)
         "text", (SqlDbType.Text, "System.String", false)
         "varchar", (SqlDbType.VarChar, "System.String", false)
 
         // unicode character strings
-        "nchar", (SqlDbType.NChar, "System.String", true)
+        "nchar", (SqlDbType.NChar, "System.String", false)
         "ntext", (SqlDbType.NText, "System.String", false)
         "nvarchar", (SqlDbType.NVarChar, "System.String", false)
         "sysname", (SqlDbType.NVarChar, "System.String", false)

--- a/tests/SqlClient.Tests/TVPTests.fs
+++ b/tests/SqlClient.Tests/TVPTests.fs
@@ -165,3 +165,23 @@ let UsingMappedTVPInQuery() =
         |> Seq.toList
 
     Assert.Equal<_ list>(expected, actual)
+
+type MappedTVPFixed = 
+    SqlCommandProvider<"
+        SELECT myId, myName from @input
+    ", ConnectionStrings.AdventureWorksLiteral, TableVarMapping = "@input=dbo.MyTableTypeFixed">
+[<Fact>]
+let UsingMappedTVPFixedInQuery() = 
+    printfn "%s" ConnectionStrings.AdventureWorksLiteral
+    use cmd = new MappedTVPFixed(ConnectionStrings.AdventureWorksLiteral)
+    let expected = [ 
+        1, Some "monkey"
+        2, Some "donkey"
+    ]
+
+    let actual =
+        cmd.Execute(input = [ for id, name in expected -> MappedTVPFixed.MyTableTypeFixed(id, name) ])
+        |> Seq.map(fun x -> x.myId, x.myName |> Option.map (fun s -> s.Trim()))
+        |> Seq.toList
+
+    Assert.Equal<_ list>(expected, actual)

--- a/tests/SqlClient.Tests/extensions.sql
+++ b/tests/SqlClient.Tests/extensions.sql
@@ -90,6 +90,9 @@ GO
 IF TYPE_ID(N'Person.MyTableType') IS NOT NULL
 	DROP TYPE Person.MyTableType
 GO
+IF TYPE_ID(N'dbo.MyTableTypeFixed') IS NOT NULL
+	DROP TYPE dbo.MyTableTypeFixed
+GO
 IF TYPE_ID(N'dbo.u_int64') IS NOT NULL
 	DROP TYPE dbo.u_int64
 GO
@@ -110,6 +113,9 @@ CREATE TYPE dbo.MyTableType AS TABLE (myId int not null, myName nvarchar(30) nul
 GO
 
 CREATE TYPE Person.MyTableType AS TABLE (myId int not null, myName nvarchar(30) null)
+GO
+
+CREATE TYPE dbo.MyTableTypeFixed AS TABLE (myId int not null, myName nchar(30) null)
 GO
 
 CREATE TYPE dbo.SingleElementType AS TABLE (myId int not null)


### PR DESCRIPTION
This is an update to #313 to fix #312.