### PR TITLE
Invalidate SqlFile type when referenced SQL file is modified.

### DIFF
--- a/src/SqlClient.DesignTime/ProvidedTypesCache.fs
+++ b/src/SqlClient.DesignTime/ProvidedTypesCache.fs
@@ -8,5 +8,11 @@ type TypeName = string
 type Cache<'a>() =
     let cache = ConcurrentDictionary<TypeName, Lazy<'a>>()
 
+    member __.TryGetValue(typeName: TypeName) =
+        cache.TryGetValue(typeName)
+
     member __.GetOrAdd(typeName: TypeName, value: Lazy<'a>): 'a = 
         cache.GetOrAdd(typeName, value).Value
+
+    member __.Remove(typeName: TypeName) =
+        cache.TryRemove(typeName) |> ignore


### PR DESCRIPTION
This will prevent Visual Studio from caching created types until VS is restarted or until project is unloaded and reloaded.