### PR TITLE
Allow timeout on data table Update commands

### DIFF
--- a/tests/SqlClient.Tests/extensions.sql
+++ b/tests/SqlClient.Tests/extensions.sql
@@ -69,6 +69,11 @@ IF OBJECT_ID(N'Sales.UnitedKingdomOrders') IS NOT NULL
 	DROP TABLE Sales.UnitedKingdomOrders
 GO
 
+--TRIGGERS
+IF OBJECT_ID(N'Production.tr_Location_Slow') IS NOT NULL
+	DROP TRIGGER Production.tr_Location_Slow
+GO
+
 -- SYNONYMs
 
 IF OBJECT_ID(N'HumanResources.GetContactInformation') IS NOT NULL
@@ -311,6 +316,18 @@ GO
 
 
 GO 
+
+--TRIGGERS
+CREATE TRIGGER Production.tr_Location_Slow ON Production.Location FOR UPDATE, DELETE
+AS
+	DECLARE @count int = (SELECT COUNT(*) FROM inserted WHERE Name = 'Slow Trigger')
+
+	IF @count > 0
+	BEGIN
+		WAITFOR DELAY '00:00:15'
+	END
+GO
+
 --SYNONYMS
 
 CREATE SYNONYM HumanResources.GetContactInformation FOR dbo.ufnGetContactInformation;


### PR DESCRIPTION
I think this is a pretty simple implementation for Issue #324.

I ended up putting in kind of a goofy test with a trigger since there's no direct access to SQL in that scenario.  Since it's a timeout test, I put in the 'Skip' flag on the test to match other timeout tests I saw.