### PR TITLE
Fix: non primitive out types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ local.properties
 *.suo
 *.user
 *.sln.docstates
-
+launchSettings.json
 # Build results
 
 [Dd]ebug/

--- a/src/SqlClient/Shared.fs
+++ b/src/SqlClient/Shared.fs
@@ -35,7 +35,11 @@ type Mapper private() =
             mapper values
             
     static member SetRef<'t>(r : byref<'t>, arr: (string * obj)[], i) = 
-        r <- arr.[i] |> snd |> unbox
+        let value = arr.[i] |> snd
+        r <-
+            match value with
+            | :? 't as v -> v
+            | _ (* dbnull *) -> Unchecked.defaultof<'t>
 
 type Column = {
     Name: string

--- a/tests/SqlClient.Tests/ProgrammabilityTests.fs
+++ b/tests/SqlClient.Tests/ProgrammabilityTests.fs
@@ -232,6 +232,30 @@ let ResultSetAndOutParam() =
     Assert.Equal<_ list>([ Some "donkey" ], [ for x in result -> x.myName ] )
     Assert.Equal(2L, !total)
 
+// Fix #340: 
+//    The type provider cannot use Expr.Value(Activator.CreateInstance(t),t) for
+//    non primitive types, like System.Guid.
+//    It now use Expr.DefaultValue(t) for non primite types.
+//    The PassGuid SP copies the input guid to the output parameter when the boolean
+//    parameter is true, and let the out parameter uninitialized when false
+[<Fact>]
+let NonPrimitiveOutParam() =
+    let guid = Guid.NewGuid()
+    let cmd = new AdventureWorks.dbo.PassGuid()
+    let _,result = cmd.Execute(guid, true)
+    Assert.Equal(guid, result)
+
+// Fix #340: 
+//    When an output parameter has not been set, its value is DBNull which cannot
+//    be unboxed. The fix sets the parameter to defaultOf<'t>.
+//    The PassGuid SP copies the input guid to the output parameter when the boolean
+//    parameter is true, and let the out parameter uninitialized when false
+[<Fact>]
+let NonPrimitiveNullOutParam() =
+    let guid = Guid.NewGuid()
+    let cmd = new AdventureWorks.dbo.PassGuid()
+    let _,result = cmd.Execute(guid, false)
+    Assert.Equal(Guid.Empty, result)
 
 [<Fact>]
 let PassingImageAsParamDoesntGetCut() = 

--- a/tests/SqlClient.Tests/extensions.sql
+++ b/tests/SqlClient.Tests/extensions.sql
@@ -7,6 +7,9 @@ USE AdventureWorks2012
 IF OBJECT_ID('dbo.AddRef') IS NOT NULL 
 	DROP PROCEDURE dbo.AddRef;
 GO
+IF OBJECT_ID('dbo.PassGuid') IS NOT NULL 
+	DROP PROCEDURE dbo.PassGuid;
+GO
 IF OBJECT_ID('dbo.MyProc') IS NOT NULL
 	DROP PROCEDURE dbo.MyProc;
 GO
@@ -166,6 +169,16 @@ AS
 BEGIN
 	SET @sum = @x + @y
 	RETURN (@x + @y)
+END
+GO
+
+CREATE PROCEDURE dbo.PassGuid @x AS UNIQUEIDENTIFIER, @b AS BIT, @result AS UNIQUEIDENTIFIER OUTPUT 
+AS
+BEGIN
+	IF (@b = 1)
+	BEGIN
+		SET @result = @x 
+	END
 END
 GO
 


### PR DESCRIPTION
This is a fix for non primitive out types in stored procedures.

I had a case with a output parameter of type Guid, the type provider could not use the Expr.Value(Activator.CreateInstance(…)) since it can do so only for primive types.
In the case of a non primite type, we use Expr.DefaultValue(t) which calls the default ctor.

The change in SetRef<'t> was necessary to set the output value to default<'t> when the parameter value is actually DBNull. This raise the question of actually making it optional…
