### PR TITLE
[experimental] Schema metadata

### DIFF
--- a/src/SqlClient.DesignTime/DesignTime.fs
+++ b/src/SqlClient.DesignTime/DesignTime.fs
@@ -277,13 +277,8 @@ type DesignTime private() =
         dataRowType.AddMember tableProperty
 
         let getColumnsSerializedSchema columns =
-            columns 
-            |> List.map (fun x ->
-                let nullable = x.Nullable || x.HasDefaultConstraint
-                sprintf "%s\t%s\t%b\t%i\t%b\t%b\t%b" 
-                    x.Name x.TypeInfo.ClrTypeFullName nullable x.MaxLength x.ReadOnly x.Identity x.PartOfUniqueKey                                 
-            ) 
-            |> String.concat "\n"
+          let columns = List.toArray columns 
+          Encoding.serialize columns
 
         let ctorCode =
             fun _ ->
@@ -538,7 +533,7 @@ type DesignTime private() =
 
         let parameters, sqlMetas = 
             List.unzip [ 
-                for p in t.TableTypeColumns.Value do
+                for p in t.TableTypeColumns do
                     let name = p.Name
                     let param = ProvidedParameter( name, p.GetProvidedType(), ?optionalValue = if p.Nullable then Some null else None) 
                     let sqlMeta =
@@ -553,7 +548,7 @@ type DesignTime private() =
             ] 
 
         let ctor = ProvidedConstructor( parameters, fun args -> 
-            let optionsToNulls = QuotationsFactory.MapArrayNullableItems(List.ofArray t.TableTypeColumns.Value, "MapArrayOptionItemToObj") 
+            let optionsToNulls = QuotationsFactory.MapArrayNullableItems(List.ofArray t.TableTypeColumns, "MapArrayOptionItemToObj") 
 
             <@@
                 let values: obj[] = %%Expr.NewArray(typeof<obj>, [ for a in args -> Expr.Coerce(a, typeof<obj>) ])

--- a/src/SqlClient.DesignTime/DesignTime.fs
+++ b/src/SqlClient.DesignTime/DesignTime.fs
@@ -357,7 +357,7 @@ type DesignTime private() =
 
                     let providedType = 
                         match outputColumns with
-                        | [ x ] -> x.GetProvidedType()
+                        | [ x ] -> x.GetProvidedType(?unitsOfMeasurePerSchema = unitsOfMeasurePerSchema)
                         | xs -> Microsoft.FSharp.Reflection.FSharpType.MakeTupleType [| for x in xs -> x.GetProvidedType(?unitsOfMeasurePerSchema = unitsOfMeasurePerSchema) |]
 
                     let clrTypeName = erasedToTupleType.FullName

--- a/src/SqlClient.DesignTime/DesignTime.fs
+++ b/src/SqlClient.DesignTime/DesignTime.fs
@@ -140,7 +140,7 @@ type DesignTime private() =
 
         m
 
-    static member internal GetRecordType(columns: Column list, ?unitsOfMeasurePerSchema) =
+    static member internal GetRecordType(columns: Column list, unitsOfMeasurePerSchema) =
         
         columns 
             |> Seq.groupBy (fun x -> x.Name) 
@@ -155,7 +155,7 @@ type DesignTime private() =
 
                 if propertyName = "" then failwithf "Column #%i doesn't have name. Only columns with names accepted. Use explicit alias." (i + 1)
                     
-                let propType = col.GetProvidedType(?unitsOfMeasurePerSchema = unitsOfMeasurePerSchema)
+                let propType = col.GetProvidedType(unitsOfMeasurePerSchema)
 
                 let property = ProvidedProperty(propertyName, propType, getterCode = fun args -> <@@ (unbox<DynamicRecord> %%args.[0]).[propertyName] @@>)
 
@@ -191,14 +191,14 @@ type DesignTime private() =
             let setter = QuotationsFactory.GetBody("SetNonNullableValueInDataRow", column.TypeInfo.ClrType, name)
             getter, setter
 
-    static member internal GetDataRowType (columns: Column list, ?unitsOfMeasurePerSchema) = 
+    static member internal GetDataRowType (columns: Column list, unitsOfMeasurePerSchema) = 
         let rowType = ProvidedTypeDefinition("Row", Some typeof<DataRow>)
 
         columns |> List.mapi(fun i col ->
 
             if col.Name = "" then failwithf "Column #%i doesn't have name. Only columns with names accepted. Use explicit alias." (i + 1)
 
-            let propertyType = col.GetProvidedType(?unitsOfMeasurePerSchema = unitsOfMeasurePerSchema)
+            let propertyType = col.GetProvidedType(unitsOfMeasurePerSchema)
 
             let getter, setter = DesignTime.GetDataRowPropertyGetterAndSetterCode col
             let property = ProvidedProperty(col.Name, propertyType, getterCode = getter, ?setterCode =
@@ -308,7 +308,7 @@ type DesignTime private() =
 
         tableProvidedType
 
-    static member internal GetOutputTypes (outputColumns: Column list, resultType, rank: ResultRank, hasOutputParameters, ?unitsOfMeasurePerSchema) =    
+    static member internal GetOutputTypes (outputColumns: Column list, resultType, rank: ResultRank, hasOutputParameters, unitsOfMeasurePerSchema) =    
         if resultType = ResultType.DataReader 
         then 
             { Single = typeof<SqlDataReader>; PerRow = None }
@@ -317,7 +317,7 @@ type DesignTime private() =
             { Single = typeof<int>; PerRow = None }
         elif resultType = ResultType.DataTable 
         then
-            let dataRowType = DesignTime.GetDataRowType(outputColumns, ?unitsOfMeasurePerSchema = unitsOfMeasurePerSchema)
+            let dataRowType = DesignTime.GetDataRowType(outputColumns, unitsOfMeasurePerSchema)
             let dataTableType = DesignTime.GetDataTableType("Table", dataRowType, outputColumns, CommandResultTable)
             dataTableType.AddMember dataRowType
 
@@ -329,14 +329,14 @@ type DesignTime private() =
                 then
                     let column0 = outputColumns.Head
                     let erasedTo = column0.ErasedToType
-                    let provided = column0.GetProvidedType(?unitsOfMeasurePerSchema = unitsOfMeasurePerSchema)
+                    let provided = column0.GetProvidedType(unitsOfMeasurePerSchema)
                     let values = Var("values", typeof<obj[]>)
                     let indexGet = Expr.Call(Expr.Var values, typeof<Array>.GetMethod("GetValue",[|typeof<int>|]), [Expr.Value 0])
                     provided, erasedTo, Expr.Lambda(values,  indexGet) 
 
                 elif resultType = ResultType.Records 
                 then 
-                    let provided = DesignTime.GetRecordType(outputColumns, ?unitsOfMeasurePerSchema = unitsOfMeasurePerSchema)
+                    let provided = DesignTime.GetRecordType(outputColumns, unitsOfMeasurePerSchema)
                     let names = Expr.NewArray(typeof<string>, outputColumns |> List.map (fun x -> Expr.Value(x.Name))) 
                     let mapping = 
                         <@@ 
@@ -357,8 +357,8 @@ type DesignTime private() =
 
                     let providedType = 
                         match outputColumns with
-                        | [ x ] -> x.GetProvidedType(?unitsOfMeasurePerSchema = unitsOfMeasurePerSchema)
-                        | xs -> Microsoft.FSharp.Reflection.FSharpType.MakeTupleType [| for x in xs -> x.GetProvidedType(?unitsOfMeasurePerSchema = unitsOfMeasurePerSchema) |]
+                        | [ x ] -> x.GetProvidedType(unitsOfMeasurePerSchema)
+                        | xs -> Microsoft.FSharp.Reflection.FSharpType.MakeTupleType [| for x in xs -> x.GetProvidedType(unitsOfMeasurePerSchema) |]
 
                     let clrTypeName = erasedToTupleType.FullName
                     let mapping = <@@ Microsoft.FSharp.Reflection.FSharpValue.PreComputeTupleConstructor (Type.GetType(clrTypeName, throwOnError = true))  @@>
@@ -527,7 +527,7 @@ type DesignTime private() =
         else
             None
 
-    static member internal CreateUDTT(t: TypeInfo) = 
+    static member internal CreateUDTT(t: TypeInfo, unitsOfMeasurePerSchema) = 
         assert(t.TableType)
         let rowType = ProvidedTypeDefinition(t.UdttName, Some typeof<obj>, hideObjectMethods = true)
 
@@ -535,7 +535,7 @@ type DesignTime private() =
             List.unzip [ 
                 for p in t.TableTypeColumns do
                     let name = p.Name
-                    let param = ProvidedParameter( name, p.GetProvidedType(), ?optionalValue = if p.Nullable then Some null else None) 
+                    let param = ProvidedParameter( name, p.GetProvidedType(unitsOfMeasurePerSchema), ?optionalValue = if p.Nullable then Some null else None) 
                     let sqlMeta =
                         let dbType = p.TypeInfo.SqlDbType
                         if p.TypeInfo.IsFixedLength
@@ -571,7 +571,7 @@ type DesignTime private() =
         rowType
 
                 
-    static member internal GetExecuteArgs(cmdProvidedType: ProvidedTypeDefinition, sqlParameters: Parameter list, udttsPerSchema: Dictionary<_, ProvidedTypeDefinition>, ?unitsOfMeasurePerSchema) = 
+    static member internal GetExecuteArgs(cmdProvidedType: ProvidedTypeDefinition, sqlParameters: Parameter list, udttsPerSchema: IDictionary<_, ProvidedTypeDefinition>, unitsOfMeasurePerSchema) = 
         [
             for p in sqlParameters do
                 assert p.Name.StartsWith("@")
@@ -583,13 +583,13 @@ type DesignTime private() =
                         if p.Optional 
                         then 
                             assert(p.Direction = ParameterDirection.Input)
-                            ProvidedParameter(parameterName, parameterType = typedefof<_ option>.MakeGenericType( p.TypeInfo.ClrType) , optionalValue = null)
+                            ProvidedParameter(parameterName, parameterType = typedefof<_ option>.MakeGenericType(p.TypeInfo.ClrType) , optionalValue = null)
                         else
                             if p.Direction.HasFlag(ParameterDirection.Output)
                             then
                                 ProvidedParameter(parameterName, parameterType = p.TypeInfo.ClrType.MakeByRefType(), isOut = true)
                             else                                 
-                                ProvidedParameter(parameterName, parameterType = p.GetProvidedType(?unitsOfMeasurePerSchema = unitsOfMeasurePerSchema), ?optionalValue = p.DefaultValue)
+                                ProvidedParameter(parameterName, parameterType = p.GetProvidedType(unitsOfMeasurePerSchema), ?optionalValue = p.DefaultValue)
                     else
                         assert(p.Direction = ParameterDirection.Input)
 
@@ -598,7 +598,7 @@ type DesignTime private() =
                             then //SqlCommandProvider case
                                 match cmdProvidedType.GetNestedType(p.TypeInfo.UdttName) with 
                                 | null -> 
-                                    let rowType = DesignTime.CreateUDTT(p.TypeInfo)
+                                    let rowType = DesignTime.CreateUDTT(p.TypeInfo, unitsOfMeasurePerSchema)
                                     cmdProvidedType.AddMember rowType
                                     rowType
                                 | x -> downcast x //same type appears more than once
@@ -660,14 +660,14 @@ type DesignTime private() =
                 yield upcast ProvidedMethod(factoryMethodName.Value, parameters2, returnType = cmdProvidedType, isStatic = true, invokeCode = body2)
         ]
 
-    static member private CreateTempTableRecord(name, cols) =
+    static member private CreateTempTableRecord(name, cols, unitsOfMeasurePerSchema) =
         let rowType = ProvidedTypeDefinition(name, Some typeof<obj>, hideObjectMethods = true)
 
         let parameters =
             [
                 for (p : Column) in cols do
                     let name = p.Name
-                    let param = ProvidedParameter( name, p.GetProvidedType(), ?optionalValue = if p.Nullable then Some null else None)
+                    let param = ProvidedParameter( name, p.GetProvidedType(unitsOfMeasurePerSchema), ?optionalValue = if p.Nullable then Some null else None)
                     yield param
             ]
 
@@ -684,7 +684,7 @@ type DesignTime private() =
         rowType
 
     // Changes any temp tables in to a global temp table (##name) then creates them on the open connection.
-    static member internal SubstituteTempTables(connection, commandText: string, tempTableDefinitions : string, connectionId) =
+    static member internal SubstituteTempTables(connection, commandText: string, tempTableDefinitions : string, connectionId, unitsOfMeasurePerSchema) =
         // Extract and temp tables
         let tempTableRegex = Regex("#([a-z0-9\-_]+)", RegexOptions.IgnoreCase)
         let tempTableNames =
@@ -706,7 +706,7 @@ type DesignTime private() =
                     let cols = DesignTime.GetOutputColumns(connection, "SELECT * FROM #"+name, [], isStoredProcedure = false)
                     use drop = new SqlCommand("DROP TABLE #"+name, connection)
                     drop.ExecuteScalar() |> ignore
-                    DesignTime.CreateTempTableRecord(name, cols), cols)
+                    DesignTime.CreateTempTableRecord(name, cols, unitsOfMeasurePerSchema), cols)
 
             let parameters =
                 tableTypes

--- a/src/SqlClient.DesignTime/DesignTime.fs
+++ b/src/SqlClient.DesignTime/DesignTime.fs
@@ -537,8 +537,10 @@ type DesignTime private() =
                     let name = p.Name
                     let param = ProvidedParameter( name, p.GetProvidedType(unitsOfMeasurePerSchema), ?optionalValue = if p.Nullable then Some null else None) 
                     let sqlMeta =
-                        let dbType = p.TypeInfo.SqlDbType
-                        if p.TypeInfo.IsFixedLength
+                        let typeInfo = p.GetTypeInfoConsideringUDDT()
+                        let dbType = typeInfo.SqlDbType
+                        
+                        if typeInfo.IsFixedLength
                         then <@@ SqlMetaData(name, dbType) @@>
                         else 
                             let maxLength = p.MaxLength

--- a/src/SqlClient.DesignTime/QuotationsFactory.fs
+++ b/src/SqlClient.DesignTime/QuotationsFactory.fs
@@ -65,10 +65,7 @@ type QuotationsFactory private() =
         @> 
 
     static member internal MapArrayNullableItems(outputColumns : Column list, mapper : string) = 
-        let columnTypes, isNullableColumn = outputColumns |> List.map (fun c -> c.TypeInfo.ClrTypeFullName, c.Nullable) |> List.unzip
-        QuotationsFactory.MapArrayNullableItems(columnTypes, isNullableColumn, mapper)            
-
-    static member internal MapArrayNullableItems(columnTypes : string list, isNullableColumn : bool list, mapper : string) = 
+        let columnTypes, isNullableColumn = outputColumns |> List.map (fun c -> c.GetTypeInfoConsideringUDDT().ClrTypeFullName, c.Nullable) |> List.unzip
         assert(columnTypes.Length = isNullableColumn.Length)
         let arr = Var("_", typeof<obj[]>)
         let body =
@@ -79,7 +76,7 @@ type QuotationsFactory private() =
                 then 
                     typeof<QuotationsFactory>
                         .GetMethod(mapper, BindingFlags.NonPublic ||| BindingFlags.Static)
-                        .MakeGenericMethod( Type.GetType( typeName, throwOnError = true))
+                        .MakeGenericMethod(Type.GetType(typeName, throwOnError = true))
                         .Invoke(null, [| box(Expr.Var arr); box index |])
                         |> unbox
                         |> Some

--- a/src/SqlClient.DesignTime/SqlClient.DesignTime.fsproj
+++ b/src/SqlClient.DesignTime/SqlClient.DesignTime.fsproj
@@ -10,7 +10,6 @@
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
-    
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.1.18" Condition="'$(TargetFramework)' == 'net40'" />
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition="'$(TargetFramework)' == 'net461'" />
@@ -63,6 +62,7 @@
     <Compile Include="SqlClientProvider.fs" />
     <Compile Include="SqlEnumProvider.fs" />
     <Compile Include="SqlFileProvider.fs" />
+    <Content Include="paket.references" />
     <None Include="Scripts\Scratchpad.fsx" />
     <None Include="Scripts\ReverseLineOrderForNotex.fsx" />
     <None Include="Scripts\XE.fsx" />

--- a/src/SqlClient.DesignTime/SqlClient.DesignTime.fsproj
+++ b/src/SqlClient.DesignTime/SqlClient.DesignTime.fsproj
@@ -58,8 +58,8 @@
     <Compile Include="DesignTime.fs" />
     <Compile Include="SingleFileChangeMonitor.fs" />
     <Compile Include="SingleRootTypeProvider.fs" />
-    <Compile Include="SqlCommandProvider.fs" />
     <Compile Include="SqlClientProvider.fs" />
+    <Compile Include="SqlCommandProvider.fs" />
     <Compile Include="SqlEnumProvider.fs" />
     <Compile Include="SqlFileProvider.fs" />
     <Content Include="paket.references" />

--- a/src/SqlClient.DesignTime/SqlClientExtensions.fs
+++ b/src/SqlClient.DesignTime/SqlClientExtensions.fs
@@ -47,7 +47,13 @@ type internal TypeInfoPerConnectionStringCache() =
         raise (new InvalidOperationException(sprintf "types for connection %s were not retrieved!" connectionString))
     )
 
-  member x.DoIfConnectionStringNotRegistered f = lock f
+  member x.DoIfConnectionStringNotRegistered connectionString ifAlreadyDone f = 
+    lock (fun () ->
+      if x.ContainsConnectionString connectionString then
+          ifAlreadyDone ()
+      else
+          f ()
+    )
     
 let internal sqlDataTypesCache = new TypeInfoPerConnectionStringCache()  
 let internal findTypeInfoBySqlEngineTypeId (connStr, system_type_id, user_type_id : int option) = 
@@ -492,7 +498,10 @@ type SqlConnection with
             ]
 
     member internal this.LoadDataTypesMap() = 
-        sqlDataTypesCache.DoIfConnectionStringNotRegistered(fun () ->
+        sqlDataTypesCache.DoIfConnectionStringNotRegistered 
+          this.ConnectionString 
+          (fun () -> sqlDataTypesCache.GetTypesForConnectionString this.ConnectionString)
+          (fun () ->
             assert (this.State = ConnectionState.Open)
             
             let sqlEngineTypes, tableVariableTypes = 
@@ -552,17 +561,20 @@ order by
 
             let getProvidedType name is_user_defined is_table_type system_type_id user_type_id =
                 match providerTypes.TryGetValue(name) with
-                | true, value -> value
+                | true, value -> Some value
                 | false, _ when is_user_defined && not is_table_type ->
                     let type_name = sqlEngineTypes.[system_type_id,user_type_id].name
-                    //let system_type_name = t.name
+                    
                     match providerTypes.TryGetValue type_name with
                     | false, _ -> 
-                        let type_name = sqlEngineTypes.[system_type_id,int system_type_id].name
-                        providerTypes.[type_name]
-                    | true, item -> item
+                        match sqlEngineTypes.TryGetValue ((system_type_id,int system_type_id)) with
+                        | false, _ -> None
+                        | true, sqlType -> 
+                        let type_name = sqlType.name
+                        Some providerTypes.[type_name]
+                    | true, item -> Some item
                 | false, _ when is_table_type -> 
-                    SqlDbType.Structured, null, false
+                    Some (SqlDbType.Structured, null, false)
                 | _ -> failwith ("Unexpected type: " + name)
 
             let getProvidedTypeForSqlTypeEntry (x:SqlTypeEntry) = getProvidedType x.name x.is_user_defined x.is_table_type x.system_type_id x.user_type_id
@@ -570,7 +582,7 @@ order by
             let rec makeColumn column =
                 { 
                     Column.Name       = column.name
-                    TypeInfo          = makeTypeInfo sqlEngineTypes.[column.system_type_id, column.user_type_id]
+                    TypeInfo          = Option.get (makeTypeInfo sqlEngineTypes.[column.system_type_id, column.user_type_id]) 
                     Nullable          = column.is_nullable
                     MaxLength         = int column.max_length
                     ReadOnly          = column.is_identity || column.is_computed
@@ -580,65 +592,77 @@ order by
                     Description       = null 
                 }      
             and makeTypeInfo (entry: SqlTypeEntry) =
-                let sqldbtype, clrTypeFullName, isFixedLength = getProvidedTypeForSqlTypeEntry entry
-                let tableTypeColumns = 
-                    if entry.is_table_type then 
-                        tableVariableTypes.[entry.user_type_id] |> Array.map makeColumn
-                    else 
-                        Array.empty 
-                {
-                    TypeName         = entry.name
-                    Schema           = entry.schema_name
-                    SqlEngineTypeId  = int entry.system_type_id
-                    UserTypeId       = entry.user_type_id
-                    SqlDbType        = sqldbtype
-                    IsFixedLength    = isFixedLength
-                    ClrTypeFullName  = clrTypeFullName
-                    UdttName         = if entry.is_table_type then entry.name else ""
-                    TableTypeColumns = tableTypeColumns
-                }
+                match getProvidedTypeForSqlTypeEntry entry with
+                | None -> None
+                | Some (sqldbtype, clrTypeFullName, isFixedLength) ->
+                  let tableTypeColumns = 
+                      if entry.is_table_type then 
+                          tableVariableTypes.[entry.user_type_id] |> Array.map makeColumn
+                      else 
+                          Array.empty 
+                  Some {
+                      TypeName         = entry.name
+                      Schema           = entry.schema_name
+                      SqlEngineTypeId  = int entry.system_type_id
+                      UserTypeId       = entry.user_type_id
+                      SqlDbType        = sqldbtype
+                      IsFixedLength    = isFixedLength
+                      ClrTypeFullName  = clrTypeFullName
+                      UdttName         = if entry.is_table_type then entry.name else ""
+                      TableTypeColumns = tableTypeColumns
+                  }
 
             let typeInfosForTableTypes =
               sqlEngineTypes.Values
-              |> Seq.map (fun i -> i.user_type_id, makeTypeInfo i)
+              |> Seq.choose (fun i -> 
+                match makeTypeInfo i with
+                | Some typeInfo -> Some (i.user_type_id, typeInfo)
+                | None ->
+                    // fails when, for example, a SQLCLR type definition is on the DDL but the assembly is missing from the database.
+                    // example: AdventureWorks2012 backup in the test folder tSQLt.Private
+                    // ignoring such types
+                    None
+              )
               |> dict
             
             let typeInfos = [|
                 
                 for { name = name; system_type_id = system_type_id; user_type_id = user_type_id; is_table_type = is_table_type; schema_name = schema_name; is_user_defined = is_user_defined } in sqlEngineTypes.Values do
-                    let providerdbtype, clrTypeFullName, isFixedLength = getProvidedType name is_user_defined is_table_type system_type_id user_type_id
+                    match getProvidedType name is_user_defined is_table_type system_type_id user_type_id with
+                    | None -> ()
+                    | Some (providerdbtype, clrTypeFullName, isFixedLength) ->
                     
-                    let columns = 
-                        if is_table_type then
-                            let columns = tableVariableTypes.[user_type_id]
+                        let columns = 
+                            if is_table_type then
+                                let columns = tableVariableTypes.[user_type_id]
 
-                            columns
-                            |> Array.map (fun column -> 
-                                { 
-                                    Column.Name       = column.name
-                                    TypeInfo          = typeInfosForTableTypes.[user_type_id]
-                                    Nullable          = column.is_nullable
-                                    MaxLength         = int column.max_length
-                                    ReadOnly          = column.is_identity || column.is_computed
-                                    Identity          = column.is_identity
-                                    PartOfUniqueKey   = false
-                                    DefaultConstraint = null
-                                    Description       = null 
-                                })
-                        else
-                            Array.empty
-                    yield 
-                        {
-                            TypeName         = name
-                            Schema           = schema_name
-                            SqlEngineTypeId  = int system_type_id
-                            UserTypeId       = user_type_id
-                            SqlDbType        = providerdbtype
-                            IsFixedLength    = isFixedLength
-                            ClrTypeFullName  = clrTypeFullName
-                            UdttName         = if is_table_type then name else ""
-                            TableTypeColumns = columns 
-                        }
+                                columns
+                                |> Array.map (fun column -> 
+                                    { 
+                                        Column.Name       = column.name
+                                        TypeInfo          = typeInfosForTableTypes.[user_type_id]
+                                        Nullable          = column.is_nullable
+                                        MaxLength         = int column.max_length
+                                        ReadOnly          = column.is_identity || column.is_computed
+                                        Identity          = column.is_identity
+                                        PartOfUniqueKey   = false
+                                        DefaultConstraint = null
+                                        Description       = null 
+                                    })
+                            else
+                                Array.empty
+                        yield 
+                            {
+                                TypeName         = name
+                                Schema           = schema_name
+                                SqlEngineTypeId  = int system_type_id
+                                UserTypeId       = user_type_id
+                                SqlDbType        = providerdbtype
+                                IsFixedLength    = isFixedLength
+                                ClrTypeFullName  = clrTypeFullName
+                                UdttName         = if is_table_type then name else ""
+                                TableTypeColumns = columns 
+                            }
             |]
             sqlDataTypesCache.RegisterTypes(this.ConnectionString, typeInfos)
             typeInfos

--- a/src/SqlClient.DesignTime/SqlClientExtensions.fs
+++ b/src/SqlClient.DesignTime/SqlClientExtensions.fs
@@ -11,8 +11,10 @@ open FSharp.Data
 open System.Diagnostics
 
 type internal TypeInfoPerConnectionStringCache() =
+  let key = obj()
   let dataTypeMappings = Dictionary<string, TypeInfo[]>()
-  let lock f = lock dataTypeMappings f
+
+  let lock f = lock key f
 
   member x.Clear(reason: string) =
     lock (fun () ->
@@ -23,19 +25,31 @@ type internal TypeInfoPerConnectionStringCache() =
     lock (fun () -> dataTypeMappings.ContainsKey connectionString)
 
   member x.RegisterTypes(connectionString, types) =
-    lock (fun () -> dataTypeMappings.Add(connectionString, types))
+    lock (fun () -> 
+      if dataTypeMappings.ContainsKey connectionString then
+          #if DEBUG
+          let existingTypes = dataTypeMappings.[connectionString]
+          if existingTypes = types then
+            System.Diagnostics.Debug.WriteLine(sprintf "types existing for connection %s, old types and new types are identical" connectionString)
+          else
+            System.Diagnostics.Debug.WriteLine(sprintf "types existing for connection %s, old types and new types are different" connectionString)
+          #endif
+          dataTypeMappings.[connectionString] <- types
+      else
+        dataTypeMappings.Add(connectionString, types)
+    )
 
   member x.GetTypesForConnectionString connectionString =
     lock (fun () ->
       match dataTypeMappings.TryGetValue connectionString with
       | true, types -> types
       | false, _ -> 
-        raise (new Exception(sprintf "types for connection %s were not retrieved!" connectionString))
+        raise (new InvalidOperationException(sprintf "types for connection %s were not retrieved!" connectionString))
     )
 
   member x.DoIfConnectionStringNotRegistered f = lock f
     
-let internal sqlDataTypesCache = new TypeInfoPerConnectionStringCache()
+let internal sqlDataTypesCache = new TypeInfoPerConnectionStringCache()  
 let internal findTypeInfoBySqlEngineTypeId (connStr, system_type_id, user_type_id : int option) = 
     assert (sqlDataTypesCache.ContainsConnectionString connStr)
 
@@ -627,4 +641,5 @@ order by
                         }
             |]
             sqlDataTypesCache.RegisterTypes(this.ConnectionString, typeInfos)
+            typeInfos
     )

--- a/src/SqlClient.DesignTime/SqlClientProvider.fs
+++ b/src/SqlClient.DesignTime/SqlClientProvider.fs
@@ -57,7 +57,7 @@ type SqlProgrammabilityProvider(config : TypeProviderConfig) as this =
 """
 
         this.AddNamespace(nameSpace, [ providerType ])
-    
+
     override this.ResolveAssembly args = 
         config.ReferencedAssemblies 
         |> Array.tryFind (fun x -> AssemblyName.ReferenceMatchesDefinition(AssemblyName.GetAssemblyName x, AssemblyName args.Name)) 
@@ -80,7 +80,7 @@ type SqlProgrammabilityProvider(config : TypeProviderConfig) as this =
         let conn = new SqlConnection(designTimeConnectionString.Value)
         use closeConn = conn.UseLocally()
         conn.CheckVersion()
-        conn.LoadDataTypesMap()
+        let sqlDataTypes = conn.LoadDataTypesMap()
 
         let databaseRootType = ProvidedTypeDefinition(assembly, nameSpace, typeName, baseType = Some typeof<obj>, hideObjectMethods = true)
 
@@ -98,23 +98,23 @@ type SqlProgrammabilityProvider(config : TypeProviderConfig) as this =
 
         for schemaType in schemas do
 
-            do //User-defined table types
-                let udttsRoot = ProvidedTypeDefinition("User-Defined Table Types", Some typeof<obj>)
-                udttsRoot.AddMembersDelayed <| fun () -> 
-                    this.UDTTs (conn.ConnectionString, schemaType.Name)
-
-                udttsPerSchema.Add( schemaType.Name, udttsRoot)
-                schemaType.AddMember udttsRoot
-                
             do //Units of measure
-                let xs = this.UnitsOfMeasure (conn.ConnectionString, schemaType.Name)
+                let xs = SqlProgrammabilityProvider.UnitsOfMeasure(conn.ConnectionString, schemaType.Name, sqlDataTypes)
                 if not (List.isEmpty xs)
                 then 
                     let uomRoot = ProvidedTypeDefinition("Units of Measure", Some typeof<obj>)
                     uomRoot.AddMembers xs
                     uomPerSchema.Add( schemaType.Name, xs)
                     schemaType.AddMember uomRoot
-                
+
+            do //User-defined table types
+                let udttsRoot = ProvidedTypeDefinition("User-Defined Table Types", Some typeof<obj>)
+                udttsRoot.AddMembersDelayed <| fun () -> 
+                    this.UDTTs (conn.ConnectionString, schemaType.Name, uomPerSchema)
+
+                udttsPerSchema.Add( schemaType.Name, udttsRoot)
+                schemaType.AddMember udttsRoot
+
         for schemaType in schemas do
 
             schemaType.AddMembersDelayed <| fun() -> 
@@ -132,16 +132,16 @@ type SqlProgrammabilityProvider(config : TypeProviderConfig) as this =
 
         databaseRootType           
 
-     member internal __.UDTTs( connStr, schema) = [
+     member internal __.UDTTs( connStr, schema, unitsOfMeasurePerSchema) = [
         for t in sqlDataTypesCache.GetTypesForConnectionString connStr do
             if t.TableType && t.Schema = schema
             then 
-                yield DesignTime.CreateUDTT( t)
+                yield DesignTime.CreateUDTT(t, unitsOfMeasurePerSchema)
                 //tagProvidedType rowType
     ]
 
-     member internal __.UnitsOfMeasure( connStr, schema) = [
-        for t in sqlDataTypesCache.GetTypesForConnectionString connStr do
+     static member internal UnitsOfMeasure( connStr, schema, sqlDataTypesForConnection: FSharp.Data.TypeInfo array) = [
+        for t in sqlDataTypesForConnection do
             if t.Schema = schema && t.IsUnitOfMeasure
             then 
                 let units = ProvidedTypeDefinition( t.UnitOfMeasureName, None)

--- a/src/SqlClient.DesignTime/SqlCommandProvider.fs
+++ b/src/SqlClient.DesignTime/SqlCommandProvider.fs
@@ -106,15 +106,29 @@ type SqlCommandProvider(config : TypeProviderConfig) as this =
         let conn = new SqlConnection(designTimeConnectionString.Value)
         use closeConn = conn.UseLocally()
         conn.CheckVersion()
-        conn.LoadDataTypesMap()
-
+        let sqlDataTypes = conn.LoadDataTypesMap()
+        
+        let schemas =
+            sqlDataTypes
+            |> Seq.map (fun i -> i.RetrieveSchemas())
+            |> Seq.concat
+            |> Seq.distinct
+            |> Seq.toArray
+        
+        let uomsPerSchema =
+            [|
+              // doing it this way to avoid running a query to list the schemas, we only care about schemas having units of measure
+              for schema in schemas do 
+                  yield schema, SqlProgrammabilityProvider.UnitsOfMeasure (designTimeConnectionString.Value, schema, sqlDataTypes)
+            |]
+            |> dict
         let connectionId = Guid.NewGuid().ToString().Substring(0, 8)
 
         let designTimeSqlStatement, tempTableTypes =
             if String.IsNullOrWhiteSpace(tempTableDefinitions) then
                 sqlStatement, None
             else
-                DesignTime.SubstituteTempTables(conn, sqlStatement, tempTableDefinitions, connectionId)
+                DesignTime.SubstituteTempTables(conn, sqlStatement, tempTableDefinitions, connectionId, uomsPerSchema)
 
         let designTimeSqlStatement =
             if String.IsNullOrWhiteSpace(tableVarMapping) then
@@ -130,7 +144,8 @@ type SqlCommandProvider(config : TypeProviderConfig) as this =
             else []
 
         let rank = if singleRow then ResultRank.SingleRow else ResultRank.Sequence
-        let returnType = DesignTime.GetOutputTypes(outputColumns, resultType, rank, hasOutputParameters = false)
+        let noOutputParameters = false
+        let returnType = DesignTime.GetOutputTypes(outputColumns, resultType, rank, noOutputParameters, uomsPerSchema)
         
         let cmdProvidedType = ProvidedTypeDefinition(assembly, nameSpace, typeName, Some typeof<``ISqlCommand Implementation``>, hideObjectMethods = true)
 
@@ -184,8 +199,8 @@ type SqlCommandProvider(config : TypeProviderConfig) as this =
                 |> cmdProvidedType.AddMembers
 
         do  //AsyncExecute, Execute, and ToTraceString
-
-            let executeArgs = DesignTime.GetExecuteArgs(cmdProvidedType, parameters, udttsPerSchema = null)
+            
+            let executeArgs = DesignTime.GetExecuteArgs(cmdProvidedType, parameters, udttsPerSchema = null, unitsOfMeasurePerSchema = uomsPerSchema)
 
             let hasOutputParameters = false
             let addRedirectToISqlCommandMethod outputType name = 

--- a/src/SqlClient.DesignTime/SqlCommandProvider.fs
+++ b/src/SqlClient.DesignTime/SqlCommandProvider.fs
@@ -138,8 +138,14 @@ type SqlCommandProvider(config : TypeProviderConfig) as this =
             | _ -> ()
 
         do
+            let serializedColumns = outputColumns |> List.toArray |> Encoding.serialize
+            let serializedParameters = parameters |> List.toArray |> Encoding.serialize
             cmdProvidedType.AddMember(ProvidedProperty("ConnectionStringOrName", typeof<string>, isStatic = true, getterCode = fun _ -> <@@ connectionStringOrName @@>))
-
+            
+            if not (List.isEmpty outputColumns) then
+              cmdProvidedType.AddMember(ProvidedProperty("Columns", typeof<Column array>, isStatic = true, getterCode = fun _ -> <@@ (serializedColumns |> Encoding.deserialize) : Column array @@>)) 
+            if not (List.isEmpty parameters) then
+              cmdProvidedType.AddMember(ProvidedProperty("Parameters", typeof<Parameter array>, isStatic = true, getterCode = fun _ -> <@@ (serializedParameters |> Encoding.deserialize) : Parameter array @@>)) 
         do
             SharedLogic.alterReturnTypeAccordingToResultType returnType cmdProvidedType resultType
 

--- a/src/SqlClient/Shared.fs
+++ b/src/SqlClient/Shared.fs
@@ -225,7 +225,7 @@ module RuntimeInternals =
         let primaryKey = ResizeArray()
         for column in columns do
             let col = new DataColumn(column.Name,column.TypeInfo.ClrType)
-            col.AllowDBNull <- column.Nullable
+            col.AllowDBNull <- column.Nullable || column.HasDefaultConstraint
             col.ReadOnly <- column.ReadOnly
             col.AutoIncrement <- column.Identity
             

--- a/src/SqlClient/Shared.fs
+++ b/src/SqlClient/Shared.fs
@@ -59,17 +59,18 @@ type Mapper private() =
             | :? 't as v -> v
             | _ (* dbnull *) -> Unchecked.defaultof<'t>
 
-
+/// Resultset or User Defined Data Table Column information
+/// Remark: This is subject to change
 type [<DataContract;CLIMutable>] Column = {
-    [<DataMember>] Name              : string
-    [<DataMember>] Nullable          : bool
-    [<DataMember>] MaxLength         : int
-    [<DataMember>] ReadOnly          : bool
-    [<DataMember>] Identity          : bool
-    [<DataMember>] PartOfUniqueKey   : bool
-    [<DataMember>] DefaultConstraint : string
-    [<DataMember>] Description       : string
-    [<DataMember>] TypeInfo          : TypeInfo
+    [<DataMember>] Name              : string    /// Name of the column
+    [<DataMember>] Nullable          : bool      /// If the field is nullable
+    [<DataMember>] MaxLength         : int       /// Max Length for variable length types 
+    [<DataMember>] ReadOnly          : bool      /// Is the column readonly?
+    [<DataMember>] Identity          : bool      /// Identity (autoincremented) column
+    [<DataMember>] PartOfUniqueKey   : bool      /// Part of primary key
+    [<DataMember>] DefaultConstraint : string    /// Default value
+    [<DataMember>] Description       : string    /// Description
+    [<DataMember>] TypeInfo          : TypeInfo  /// Detailed type information
 }   with
     member this.ErasedToType = 
         if this.Nullable
@@ -111,17 +112,18 @@ type [<DataContract;CLIMutable>] Column = {
         Description = defaultArg description ""
     }
 
-
-and [<DataContract;CLIMutable>] TypeInfo = {
-    [<DataMember>] TypeName         : string
-    [<DataMember>] Schema           : string
-    [<DataMember>] SqlEngineTypeId  : int
-    [<DataMember>] UserTypeId       : int
-    [<DataMember>] SqlDbType        : SqlDbType
-    [<DataMember>] IsFixedLength    : bool 
-    [<DataMember>] ClrTypeFullName  : string
-    [<DataMember>] UdttName         : string 
-    [<DataMember>] TableTypeColumns : Column array
+/// Describes a single SQL Server Data Type
+/// Remark: This is subject to change
+and [<DataContract;CLIMutable>] TypeInfo = {       
+    [<DataMember>] TypeName         : string       /// Type name
+    [<DataMember>] Schema           : string       /// Schema owning this type (sys for system types)
+    [<DataMember>] SqlEngineTypeId  : int          /// system_type_id
+    [<DataMember>] UserTypeId       : int          /// user_type_id
+    [<DataMember>] SqlDbType        : SqlDbType    /// ADO.NET <see cref="SqlDbType"/>
+    [<DataMember>] IsFixedLength    : bool         /// Is fixed length
+    [<DataMember>] ClrTypeFullName  : string       /// Fullname of type, for use with runtime reflection
+    [<DataMember>] UdttName         : string       /// Name of the user-defined-table-type
+    [<DataMember>] TableTypeColumns : Column array /// Columns of the user-defined-table-type
 }   with
     member this.ClrType: Type = if isNull this.ClrTypeFullName then null else Type.GetType( this.ClrTypeFullName, throwOnError = true)
     member this.TableType = this.SqlDbType = SqlDbType.Structured
@@ -129,16 +131,18 @@ and [<DataContract;CLIMutable>] TypeInfo = {
     member this.IsUnitOfMeasure = this.TypeName.StartsWith("<") && this.TypeName.EndsWith(">")
     member this.UnitOfMeasureName = this.TypeName.TrimStart('<').TrimEnd('>')
 
+/// Describes a single parameter
+/// Remark: API this is subject to change
 type [<DataContract;CLIMutable>] Parameter = {
-    [<DataMember>] Name: string
-    [<DataMember>] TypeInfo: TypeInfo
-    [<DataMember>] Direction: ParameterDirection 
-    [<DataMember>] MaxLength: int
-    [<DataMember>] Precision: byte
-    [<DataMember>] Scale : byte
-    [<DataMember>] DefaultValue: obj option
-    [<DataMember>] Optional: bool
-    [<DataMember>] Description: string
+    [<DataMember>] Name         : string             /// Parameter name
+    [<DataMember>] TypeInfo     : TypeInfo           /// Parameter type details
+    [<DataMember>] Direction    : ParameterDirection /// ADO.NET <see cref="ParameterDirection"/>
+    [<DataMember>] MaxLength    : int                /// Max Length for variable length types 
+    [<DataMember>] Precision    : byte               /// Precision ???
+    [<DataMember>] Scale        : byte               /// Scale ???
+    [<DataMember>] DefaultValue : obj option         /// Default value
+    [<DataMember>] Optional     : bool               /// Is optional
+    [<DataMember>] Description  : string             /// Description
 }   with
     
     member this.Size = 

--- a/src/SqlClient/Shared.fs
+++ b/src/SqlClient/Shared.fs
@@ -84,7 +84,12 @@ type [<DataContract;CLIMutable>] Column = {
                 assert(unitsOfMeasurePerSchema.IsSome)
                 let uomType = unitsOfMeasurePerSchema.Value.[this.TypeInfo.Schema] |> List.find (fun x -> x.Name = this.TypeInfo.UnitOfMeasureName)
                 ProviderImplementation.ProvidedTypes.ProvidedMeasureBuilder.AnnotateType(this.TypeInfo.ClrType, [ uomType ])
+            elif isNull this.TypeInfo.ClrType && this.TypeInfo.TableTypeColumns.Length > 0 then
+                // we need to lookup matching uddt column to resolve the type
+                let matchingUddtColumn = this.TypeInfo.TableTypeColumns |> Array.find (fun t -> t.Name = this.Name)
+                matchingUddtColumn.TypeInfo.ClrType
             else
+                // normal parameter case
                 this.TypeInfo.ClrType
 
         if this.Nullable

--- a/src/SqlClient/Shared.fs
+++ b/src/SqlClient/Shared.fs
@@ -113,32 +113,32 @@ type [<DataContract;CLIMutable>] Column = {
 
 
 and [<DataContract;CLIMutable>] TypeInfo = {
-    [<DataMember>] TypeName       : string
-    [<DataMember>] Schema         : string
-    [<DataMember>] SqlEngineTypeId: int
-    [<DataMember>] UserTypeId     : int
-    [<DataMember>] SqlDbType      : SqlDbType
-    [<DataMember>] IsFixedLength  : bool 
-    [<DataMember>] ClrTypeFullName: string
-    [<DataMember>] UdttName       : string 
-    [<DataMember>] TableTypeColumns: Column[]
+    [<DataMember>] TypeName         : string
+    [<DataMember>] Schema           : string
+    [<DataMember>] SqlEngineTypeId  : int
+    [<DataMember>] UserTypeId       : int
+    [<DataMember>] SqlDbType        : SqlDbType
+    [<DataMember>] IsFixedLength    : bool 
+    [<DataMember>] ClrTypeFullName  : string
+    [<DataMember>] UdttName         : string 
+    [<DataMember>] TableTypeColumns : Column array
 }   with
-    member this.ClrType: Type = Type.GetType( this.ClrTypeFullName, throwOnError = true)
+    member this.ClrType: Type = if isNull this.ClrTypeFullName then null else Type.GetType( this.ClrTypeFullName, throwOnError = true)
     member this.TableType = this.SqlDbType = SqlDbType.Structured
     member this.IsValueType = not this.TableType && this.ClrType.IsValueType
     member this.IsUnitOfMeasure = this.TypeName.StartsWith("<") && this.TypeName.EndsWith(">")
     member this.UnitOfMeasureName = this.TypeName.TrimStart('<').TrimEnd('>')
 
-type Parameter = {
-    Name: string
-    TypeInfo: TypeInfo
-    Direction: ParameterDirection 
-    MaxLength: int
-    Precision: byte
-    Scale : byte
-    DefaultValue: obj option
-    Optional: bool
-    Description: string
+type [<DataContract;CLIMutable>] Parameter = {
+    [<DataMember>] Name: string
+    [<DataMember>] TypeInfo: TypeInfo
+    [<DataMember>] Direction: ParameterDirection 
+    [<DataMember>] MaxLength: int
+    [<DataMember>] Precision: byte
+    [<DataMember>] Scale : byte
+    [<DataMember>] DefaultValue: obj option
+    [<DataMember>] Optional: bool
+    [<DataMember>] Description: string
 }   with
     
     member this.Size = 


### PR DESCRIPTION
With those changes, I'm able to expose a `Columns` property on `SqlCommandProvider`.

main things about this change:
* the `Column` object used to be serialized (only a subset) as tab delimited string
* removes a select N+1 (and `lazy` wrapping) of UDDT columns which occurs if you have several UDDT being TVP defined on your schema as this was impeding me from implementing the serialization :
* put plain `lock` around sql data type cache and signal who is clearing that cache

https://github.com/fsprojects/FSharp.Data.SqlClient/blob/37a6ae50b69c97e9f9c875feec52f550640fa1b4/src/SqlClient.DesignTime/SqlClientExtensions.fs#L482-L505

I'm thinking this could be a first step toward persisting the meta data about each statement, but I figured if we like to have Columns property I could go ahead and tidy up the changes to have that.

Initial test in FSI:

![image](https://user-images.githubusercontent.com/87944/65376820-f4201000-dca4-11e9-9561-c67583d44af7.png)

![image](https://user-images.githubusercontent.com/87944/65376773-20875c80-dca4-11e9-83d4-9e3d9d2a1eb7.png)
