### PR TITLE
Improve trace string

### DIFF
--- a/tests/SqlClient.Tests/CreateCommand.fs
+++ b/tests/SqlClient.Tests/CreateCommand.fs
@@ -85,8 +85,9 @@ let columnsShouldNotBeNull2() =
 [<Fact>]
 let toTraceString() =
     let now = System.DateTime.Now
+    let universalNow = now.ToString("O")
     let num = 42
-    let expected = sprintf "exec sp_executesql N'SELECT CAST(@Date AS DATE), CAST(@Number AS INT)',N'@Date Date,@Number Int',@Date='%A',@Number='%d'" now num
+    let expected = sprintf "exec sp_executesql N'SELECT CAST(@Date AS DATE), CAST(@Number AS INT)',N'@Date Date,@Number Int',@Date='%s',@Number='%d'" universalNow num
     let cmd = DB.CreateCommand<"SELECT CAST(@Date AS DATE), CAST(@Number AS INT)", ResultType.Tuples>()
     Assert.Equal<string>(
         expected, 

--- a/tests/SqlClient.Tests/TypeProviderTest.fs
+++ b/tests/SqlClient.Tests/TypeProviderTest.fs
@@ -88,9 +88,10 @@ let singleRowOption() =
 
 [<Fact>]
 let ToTraceString() =
-    let now = DateTime.Now.ToString("O")
+    let now = DateTime.Now
+    let universalPrintedNow = now.ToString("O")
     let num = 42
-    let expected = sprintf "exec sp_executesql N'SELECT CAST(@Date AS DATE), CAST(@Number AS INT)',N'@Date Date,@Number Int',@Date='%s',@Number='%d'" now num
+    let expected = sprintf "exec sp_executesql N'SELECT CAST(@Date AS DATE), CAST(@Number AS INT)',N'@Date Date,@Number Int',@Date='%s',@Number='%d'" universalPrintedNow num
     let cmd = new SqlCommandProvider<"SELECT CAST(@Date AS DATE), CAST(@Number AS INT)", ConnectionStrings.AdventureWorksNamed, ResultType.Tuples>()
     Assert.Equal<string>(
         expected, 

--- a/tests/SqlClient.Tests/TypeProviderTest.fs
+++ b/tests/SqlClient.Tests/TypeProviderTest.fs
@@ -157,10 +157,10 @@ let ``ToTraceString double-quotes``() =
 
     
 [<Fact>]
-let ``ToTraceString double-quotes in paramter``() =    
+let ``ToTraceString double-quotes in parameter``() =    
     use cmd = new SqlCommandProvider<"SELECT * FROM Sales.Currency WHERE CurrencyCode = @CurrencyCode", ConnectionStrings.AdventureWorksNamed>()    
     Assert.Equal<string>(
-        expected = "exec sp_executesql N'DELETE FROM Sales.Currency WHERE CurrencyCode = @Code',N'@Code NChar(3)',@Code='A''B'",
+        expected = "exec sp_executesql N'SELECT * FROM Sales.Currency WHERE CurrencyCode = @CurrencyCode',N'@CurrencyCode NChar(3)',@CurrencyCode='A''B'",
         actual = cmd.ToTraceString("A'B")
     )
     


### PR DESCRIPTION
Fixes some annoying issues with the query generated by `ToTraceString`:

 - `tinyint` and `xml` data formats do have a width specifier (1 and -1 respectively), but MSSQL doesn't recognize it in input. This PR adds exceptions.
 - Parameter values in trace strings aren't escaped if they contain `'`. This PR doubles any single quotes in parameter values.
 - Date/time parameters are printed in local formats, which may or may not be accepted by the server. This PR changes them to ISO8601 format which should work regardless of MSSQL configs. _Potentially_ breaking change if someone out there is parsing trace strings using `.ParseExact`.
