### PR TITLE
More tracestring improvements

### DIFF
--- a/src/SqlClient/ISqlCommand.fs
+++ b/src/SqlClient/ISqlCommand.fs
@@ -150,8 +150,8 @@ type ``ISqlCommand Implementation``(cfg: DesignTimeConfig, connection: Connectio
              
             // helper map to resolve each parameter's target type
             let getSqlDbType name = 
-               let lookup = Map.ofSeq <| Seq.zip (parameters     |> Seq.map (fun p -> p.name))
-                                                 (cmd.Parameters |> Seq.map (fun p -> p.SqlDbType))
+               let lookup = Map.ofSeq <| Seq.zip (parameters     |> Seq.map (fun (name, value) -> name))
+                                                 (cmd.Parameters |> Seq.cast<SqlParameter> |> Seq.map (fun p -> p.SqlDbType))
                Map.find name lookup
             
             seq {

--- a/src/SqlClient/ISqlCommand.fs
+++ b/src/SqlClient/ISqlCommand.fs
@@ -134,8 +134,13 @@ type ``ISqlCommand Implementation``(cfg: DesignTimeConfig, connection: Connectio
         member this.ToTraceString parameters =  
             ``ISqlCommand Implementation``.SetParameters(cmd, parameters)
             let parameterDefinition (p : SqlParameter) =
+                // decimal uses precision and scale instead of size
+                if p.SqlDbType = SqlDbType.Money then
+                    // maximum size is 38
+                    sprintf "%s %A(%u,%u)" p.ParameterName p.SqlDbType p.Precision p.Scale
+                    
                 // tinyint and Xml have size 1 and -1 respectively, but MSSQL will throw if they are specified
-                if p.Size <> 0 && 
+                elif p.Size <> 0 && 
                    p.SqlDbType <> SqlDbType.Xml && 
                    p.SqlDbType <> SqlDbType.TinyInt then
                    

--- a/src/SqlClient/ISqlCommand.fs
+++ b/src/SqlClient/ISqlCommand.fs
@@ -135,7 +135,7 @@ type ``ISqlCommand Implementation``(cfg: DesignTimeConfig, connection: Connectio
             ``ISqlCommand Implementation``.SetParameters(cmd, parameters)
             let parameterDefinition (p : SqlParameter) =
                 // decimal uses precision and scale instead of size
-                if p.SqlDbType = SqlDbType.Money then
+                if List.contains p.SqlDbType [SqlDbType.Money; SqlDbType.SmallMoney; SqlDbType.Decimal] then
                     // maximum size is 38
                     sprintf "%s %A(%u,%u)" p.ParameterName p.SqlDbType p.Precision p.Scale
                     

--- a/src/SqlClient/ISqlCommand.fs
+++ b/src/SqlClient/ISqlCommand.fs
@@ -178,9 +178,9 @@ type ``ISqlCommand Implementation``(cfg: DesignTimeConfig, connection: Connectio
                                     match nonNullValue with
                                     // print dates with high precision (SQL datetimeoffset, datetime2) in roundtrip ISO8601 format "O"
                                     | :? System.DateTimeOffset as d -> d.ToString("O")
-                                    | :? System.DateTime as d when getSqlDbType d = SqlDbType.DateTime2 -> d.ToString("O")
+                                    | :? System.DateTime as d when getSqlDbType name = SqlDbType.DateTime2 -> d.ToString("O")
                                     // print dates with low precision (SQL datetime) in legacy format
-                                    | :? System.DateTime as d when getSqlDbType d <> SqlDbType.DateTime2 -> d.ToString("yyyy-MM-ddTHH:mm:ss.fff")                          
+                                    | :? System.DateTime as d when getSqlDbType name <> SqlDbType.DateTime2 -> d.ToString("yyyy-MM-ddTHH:mm:ss.fff")                          
                                     // print timespans in constant format "c
                                     | :? System.TimeSpan as t -> t.ToString("c")
                                     // print numeric values in culture-invariant format

--- a/src/SqlClient/ISqlCommand.fs
+++ b/src/SqlClient/ISqlCommand.fs
@@ -149,10 +149,10 @@ type ``ISqlCommand Implementation``(cfg: DesignTimeConfig, connection: Connectio
                     sprintf "%s %A" p.ParameterName p.SqlDbType 
              
             // helper map to resolve each parameter's target type
-            let getSqlDbType name = 
+            let getSqlDbType = 
                let lookup = Map.ofSeq <| Seq.zip (parameters     |> Seq.map (fun (name, value) -> name))
                                                  (cmd.Parameters |> Seq.cast<SqlParameter> |> Seq.map (fun p -> p.SqlDbType))
-               Map.find name lookup
+               fun name -> Map.find name lookup
             
             seq {
                 

--- a/src/SqlClient/ISqlCommand.fs
+++ b/src/SqlClient/ISqlCommand.fs
@@ -165,7 +165,7 @@ type ``ISqlCommand Implementation``(cfg: DesignTimeConfig, connection: Connectio
                         |> Seq.map(fun (name,value) ->   
                             // NULL isn't escaped
                             match value with
-                            | null | DBNull.Value ->  sprintf "%s=NULL" name
+                            | null | :? DBNull ->  sprintf "%s=NULL" name
                             | nonNullValue ->
                                 let printedValue =                                 
                                     match nonNullValue with

--- a/tests/SqlClient.Tests/CreateCommand.fs
+++ b/tests/SqlClient.Tests/CreateCommand.fs
@@ -84,36 +84,47 @@ let columnsShouldNotBeNull2() =
 
 module TraceTests = 
 
-    let [<Literal>] traceQuery = "SELECT CAST(@Value AS "
-    let [<Literal>] DATETIME = "DATETIME"
-    let [<Literal>] DATETIMEOFFSET = "DATETIMEOFFSET"
-    let [<Literal>] TIMESTAMP = "TIME"
-    let [<Literal>] INT = "INT"
-    let [<Literal>] DECIMAL63 = "DECIMAL(6,3)"
+    let [<Literal>] queryStart = "SELECT CAST(@Value AS "
+    let [<Literal>] queryEnd = ")"
     
-    let inline testTraceString (cmd : ^cmd) dbType (value : ^value) printedValue = 
-        let expected = sprintf "exec sp_executesql N'%s%s)',N'@Value %s',@Value=N'%s'" traceQuery dbType dbType printedValue    
+    let [<Literal>] DATETIME = "DATETIME"
+    let [<Literal>] queryDATETIME = queryStart + DATETIME + queryEnd
+    
+    let [<Literal>] DATETIMEOFFSET = "DATETIMEOFFSET"
+    let [<Literal>] queryDATETIME = queryStart + DATETIME + queryEnd
+    
+    let [<Literal>] TIMESTAMP = "TIME"
+    let [<Literal>] queryDATETIME = queryStart + DATETIME + queryEnd
+    
+    let [<Literal>] INT = "INT"
+    let [<Literal>] queryDATETIME = queryStart + DATETIME + queryEnd
+    
+    let [<Literal>] DECIMAL63 = "DECIMAL(6,3)"
+    let [<Literal>] queryDATETIME = queryStart + DECIMAL63 + queryEnd
+    
+    let inline testTraceString traceQuery (cmd : ^cmd) dbType (value : ^value) printedValue = 
+        let expected = sprintf "exec sp_executesql N'%s',N'@Value %s',@Value=N'%s'" traceQuery dbType printedValue    
         Assert.Equal<string>(expected, actual = (^cmd : (member ToTraceString : ^value -> string) (cmd, value)))
 
     [<Fact>]
     let traceDate() = 
-        testTraceString (DB.CreateCommand<traceQuery + DATETIME + ")", ResultType.Tuples>()) DATETIME (System.DateTime.Now) (System.DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff"))
+        testTraceString (DB.CreateCommand<queryDATETIME>()) DATETIME (System.DateTime.Now) (System.DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff"))
         
     [<Fact>]
     let traceDateTimeOffset() = 
-        testTraceString (DB.CreateCommand<traceQuery + DATETIMEOFFSET + ")", ResultType.Tuples>()) DATETIMEOFFSET (System.DateTimeOffset.Now) (System.DateTimeOffset.Now.ToString("O"))
+        testTraceString (DB.CreateCommand<queryDATETIMEOFFSET>()) DATETIMEOFFSET (System.DateTimeOffset.Now) (System.DateTimeOffset.Now.ToString("O"))
         
     [<Fact>]
     let traceTimestamp() =
-        testTraceString (DB.CreateCommand<traceQuery + TIMESTAMP + ")", ResultType.Tuples>()) TIMESTAMP (System.DateTime.Now.TimeOfDay) (System.DateTime.Now.TimeOfDay.ToString("c"))
+        testTraceString (DB.CreateCommand<queryTIMESTAMP>()) TIMESTAMP (System.DateTime.Now.TimeOfDay) (System.DateTime.Now.TimeOfDay.ToString("c"))
         
     [<Fact>]
     let traceInt() =
-        testTraceString (DB.CreateCommand<traceQuery + INT + ")", ResultType.Tuples>()) INT 42 "42"
+        testTraceString (DB.CreateCommand<queryINT>()) INT 42 "42"
 
     [<Fact>]
     let traceDecimal() =
-        testTraceString (DB.CreateCommand<traceQuery + DECIMAL63 + ")", ResultType.Tuples>()) DECIMAL63 123.456m (123.456m.ToString(System.Globalization.CultureInfo.InvariantCulture))
+        testTraceString (DB.CreateCommand<queryDECIMAL63>()) DECIMAL63 123.456m (123.456m.ToString(System.Globalization.CultureInfo.InvariantCulture))
 
     [<Fact>]
     let traceNull() =

--- a/tests/SqlClient.Tests/CreateCommand.fs
+++ b/tests/SqlClient.Tests/CreateCommand.fs
@@ -118,8 +118,9 @@ module TraceTests =
         
     [<Fact>]
     let traceTimestamp() =
+        let timeOfDay = System.DateTime.Now.TimeOfDay
         testTraceString queryTIMESTAMP (DB.CreateCommand<queryTIMESTAMP>()) TIMESTAMP 
-                        (System.DateTime.Now.TimeOfDay) (System.DateTime.Now.TimeOfDay.ToString("c"))
+                        timeOfDay (timeOfDay.ToString("c"))
         
     [<Fact>]
     let traceInt() =
@@ -133,7 +134,7 @@ module TraceTests =
 
     [<Fact>]
     let traceNull() =
-        let expected = sprintf "exec sp_executesql N'SELECT CAST(@Value AS NVARCHAR(20))',N'@Value NVARCHAR(20)',@Value=NULL"
+        let expected = sprintf "exec sp_executesql N'SELECT CAST(@Value AS NVARCHAR(20))',N'@Value NVarChar(20)',@Value=NULL"
         Assert.Equal<string>(expected, actual = DB.CreateCommand<"SELECT CAST(@Value AS NVARCHAR(20))">().ToTraceString(Unchecked.defaultof<string>))
 
 [<Fact>]

--- a/tests/SqlClient.Tests/CreateCommand.fs
+++ b/tests/SqlClient.Tests/CreateCommand.fs
@@ -107,24 +107,29 @@ module TraceTests =
         Assert.Equal<string>(expected, actual = (^cmd : (member ToTraceString : ^value -> string) (cmd, value)))
 
     [<Fact>]
-    let traceDate() = 
-        testTraceString (DB.CreateCommand<queryDATETIME>()) DATETIME (System.DateTime.Now) (System.DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff"))
-        
+    let traceDate() =     
+        testTraceString queryDATETIME (DB.CreateCommand<queryDATETIME>()) DATETIME 
+                        (System.DateTime.Now) (System.DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff"))
+    
     [<Fact>]
     let traceDateTimeOffset() = 
-        testTraceString (DB.CreateCommand<queryDATETIMEOFFSET>()) DATETIMEOFFSET (System.DateTimeOffset.Now) (System.DateTimeOffset.Now.ToString("O"))
+        testTraceString queryDATETIMEOFFSET (DB.CreateCommand<queryDATETIMEOFFSET>()) DATETIMEOFFSET 
+                        (System.DateTimeOffset.Now) (System.DateTimeOffset.Now.ToString("O"))
         
     [<Fact>]
     let traceTimestamp() =
-        testTraceString (DB.CreateCommand<queryTIMESTAMP>()) TIMESTAMP (System.DateTime.Now.TimeOfDay) (System.DateTime.Now.TimeOfDay.ToString("c"))
+        testTraceString queryTIMESTAMP (DB.CreateCommand<queryTIMESTAMP>()) TIMESTAMP 
+                        (System.DateTime.Now.TimeOfDay) (System.DateTime.Now.TimeOfDay.ToString("c"))
         
     [<Fact>]
     let traceInt() =
-        testTraceString (DB.CreateCommand<queryINT>()) INT 42 "42"
+        testTraceString queryINT (DB.CreateCommand<queryINT>()) INT 
+                        42 "42"
 
     [<Fact>]
     let traceDecimal() =
-        testTraceString (DB.CreateCommand<queryDECIMAL63>()) DECIMAL63 123.456m (123.456m.ToString(System.Globalization.CultureInfo.InvariantCulture))
+        testTraceString queryDECIMAL63 (DB.CreateCommand<queryDECIMAL63>()) DECIMAL63 
+                        123.456m (123.456m.ToString(System.Globalization.CultureInfo.InvariantCulture))
 
     [<Fact>]
     let traceNull() =

--- a/tests/SqlClient.Tests/CreateCommand.fs
+++ b/tests/SqlClient.Tests/CreateCommand.fs
@@ -91,13 +91,13 @@ module TraceTests =
     let [<Literal>] queryDATETIME = queryStart + DATETIME + queryEnd
     
     let [<Literal>] DATETIMEOFFSET = "DATETIMEOFFSET"
-    let [<Literal>] queryDATETIMEOFFSET = queryStart + DATETIME + queryEnd
+    let [<Literal>] queryDATETIMEOFFSET = queryStart + DATETIMEOFFSET + queryEnd
     
     let [<Literal>] TIMESTAMP = "TIME"
-    let [<Literal>] queryTIMESTAMP = queryStart + DATETIME + queryEnd
+    let [<Literal>] queryTIMESTAMP = queryStart + TIMESTAMP + queryEnd
     
     let [<Literal>] INT = "INT"
-    let [<Literal>] queryINT = queryStart + DATETIME + queryEnd
+    let [<Literal>] queryINT = queryStart + INT + queryEnd
     
     let [<Literal>] DECIMAL63 = "DECIMAL(6,3)"
     let [<Literal>] queryDECIMAL63 = queryStart + DECIMAL63 + queryEnd

--- a/tests/SqlClient.Tests/CreateCommand.fs
+++ b/tests/SqlClient.Tests/CreateCommand.fs
@@ -87,19 +87,19 @@ module TraceTests =
     let [<Literal>] queryStart = "SELECT CAST(@Value AS "
     let [<Literal>] queryEnd = ")"
     
-    let [<Literal>] DATETIME = "DATETIME"
+    let [<Literal>] DATETIME = "DateTime"
     let [<Literal>] queryDATETIME = queryStart + DATETIME + queryEnd
     
-    let [<Literal>] DATETIMEOFFSET = "DATETIMEOFFSET"
+    let [<Literal>] DATETIMEOFFSET = "DateTimeOffset"
     let [<Literal>] queryDATETIMEOFFSET = queryStart + DATETIMEOFFSET + queryEnd
     
-    let [<Literal>] TIMESTAMP = "TIME"
+    let [<Literal>] TIMESTAMP = "Time"
     let [<Literal>] queryTIMESTAMP = queryStart + TIMESTAMP + queryEnd
     
-    let [<Literal>] INT = "INT"
+    let [<Literal>] INT = "Int"
     let [<Literal>] queryINT = queryStart + INT + queryEnd
     
-    let [<Literal>] DECIMAL63 = "DECIMAL(6,3)"
+    let [<Literal>] DECIMAL63 = "Decimal(6,3)"
     let [<Literal>] queryDECIMAL63 = queryStart + DECIMAL63 + queryEnd
     
     let inline testTraceString traceQuery (cmd : ^cmd) dbType (value : ^value) printedValue = 

--- a/tests/SqlClient.Tests/CreateCommand.fs
+++ b/tests/SqlClient.Tests/CreateCommand.fs
@@ -91,16 +91,16 @@ module TraceTests =
     let [<Literal>] queryDATETIME = queryStart + DATETIME + queryEnd
     
     let [<Literal>] DATETIMEOFFSET = "DATETIMEOFFSET"
-    let [<Literal>] queryDATETIME = queryStart + DATETIME + queryEnd
+    let [<Literal>] queryDATETIMEOFFSET = queryStart + DATETIME + queryEnd
     
     let [<Literal>] TIMESTAMP = "TIME"
-    let [<Literal>] queryDATETIME = queryStart + DATETIME + queryEnd
+    let [<Literal>] queryTIMESTAMP = queryStart + DATETIME + queryEnd
     
     let [<Literal>] INT = "INT"
-    let [<Literal>] queryDATETIME = queryStart + DATETIME + queryEnd
+    let [<Literal>] queryINT = queryStart + DATETIME + queryEnd
     
     let [<Literal>] DECIMAL63 = "DECIMAL(6,3)"
-    let [<Literal>] queryDATETIME = queryStart + DECIMAL63 + queryEnd
+    let [<Literal>] queryDECIMAL63 = queryStart + DECIMAL63 + queryEnd
     
     let inline testTraceString traceQuery (cmd : ^cmd) dbType (value : ^value) printedValue = 
         let expected = sprintf "exec sp_executesql N'%s',N'@Value %s',@Value=N'%s'" traceQuery dbType printedValue    

--- a/tests/SqlClient.Tests/CreateCommand.fs
+++ b/tests/SqlClient.Tests/CreateCommand.fs
@@ -93,7 +93,7 @@ module TraceTests =
     
     let inline testTraceString (cmd : ^cmd) dbType (value : ^value) printedValue = 
         let expected = sprintf "exec sp_executesql N'%s%s)',N'@Value %s',@Value=N'%s'" traceQuery dbType dbType printedValue    
-        Assert.Equal<string>(expected, actual = (^cmd : (member ToTraceString : ^value -> string) (cmd, value))
+        Assert.Equal<string>(expected, actual = (^cmd : (member ToTraceString : ^value -> string) (cmd, value)))
 
     [<Fact>]
     let traceDate() = 

--- a/tests/SqlClient.Tests/CreateCommand.fs
+++ b/tests/SqlClient.Tests/CreateCommand.fs
@@ -97,23 +97,23 @@ module TraceTests =
 
     [<Fact>]
     let traceDate() = 
-        testTraceString (DB.CreateCommand<traceQuery + DATETIME + ")">()) DATETIME (System.DateTime.Now) (System.DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff"))
+        testTraceString (DB.CreateCommand<traceQuery + DATETIME + ")", ResultType.Tuples>()) DATETIME (System.DateTime.Now) (System.DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff"))
         
     [<Fact>]
     let traceDateTimeOffset() = 
-        testTraceString (DB.CreateCommand<traceQuery + DATETIMEOFFSET + ")">()) DATETIMEOFFSET (System.DateTimeOffset.Now) (System.DateTimeOffset.Now.ToString("O"))
+        testTraceString (DB.CreateCommand<traceQuery + DATETIMEOFFSET + ")", ResultType.Tuples>()) DATETIMEOFFSET (System.DateTimeOffset.Now) (System.DateTimeOffset.Now.ToString("O"))
         
     [<Fact>]
     let traceTimestamp() =
-        testTraceString (DB.CreateCommand<traceQuery + TIMESTAMP + ")">()) TIMESTAMP (System.DateTime.Now.TimeOfDay) (System.DateTime.Now.TimeOfDay.ToString("c"))
+        testTraceString (DB.CreateCommand<traceQuery + TIMESTAMP + ")", ResultType.Tuples>()) TIMESTAMP (System.DateTime.Now.TimeOfDay) (System.DateTime.Now.TimeOfDay.ToString("c"))
         
     [<Fact>]
     let traceInt() =
-        testTraceString (DB.CreateCommand<traceQuery + INT + ")">()) INT 42 "42"
+        testTraceString (DB.CreateCommand<traceQuery + INT + ")", ResultType.Tuples>()) INT 42 "42"
 
     [<Fact>]
     let traceDecimal() =
-        testTraceString (DB.CreateCommand<traceQuery + DECIMAL63 + ")">()) DECIMAL63 123.456m (123.456m.ToString(System.Globalization.CultureInfo.InvariantCulture))
+        testTraceString (DB.CreateCommand<traceQuery + DECIMAL63 + ")", ResultType.Tuples>()) DECIMAL63 123.456m (123.456m.ToString(System.Globalization.CultureInfo.InvariantCulture))
 
     [<Fact>]
     let traceNull() =

--- a/tests/SqlClient.Tests/CreateCommand.fs
+++ b/tests/SqlClient.Tests/CreateCommand.fs
@@ -82,17 +82,43 @@ let columnsShouldNotBeNull2() =
     let _,_,_,_,precision = cmd.Execute().Value
     Assert.Equal(None, precision) 
 
-[<Fact>]
-let toTraceString() =
-    let now = System.DateTime.Now
-    let universalNow = now.ToString("O")
-    let num = 42
-    let expected = sprintf "exec sp_executesql N'SELECT CAST(@Date AS DATE), CAST(@Number AS INT)',N'@Date Date,@Number Int',@Date='%s',@Number='%d'" universalNow num
-    let cmd = DB.CreateCommand<"SELECT CAST(@Date AS DATE), CAST(@Number AS INT)", ResultType.Tuples>()
-    Assert.Equal<string>(
-        expected, 
-        actual = cmd.ToTraceString( now, num)
-    )
+module TraceTests = 
+
+    let [<Literal>] traceQuery = "SELECT CAST(@Value AS "
+    let [<Literal>] DATETIME = "DATETIME"
+    let [<Literal>] DATETIMEOFFSET = "DATETIMEOFFSET"
+    let [<Literal>] TIMESTAMP = "TIME"
+    let [<Literal>] INT = "INT"
+    let [<Literal>] DECIMAL63 = "DECIMAL(6,3)"
+    
+    let inline testTraceString (cmd : ^cmd) dbType (value : ^value) printedValue = 
+        let expected = sprintf "exec sp_executesql N'%s%s)',N'@Value %s',@Value=N'%s'" traceQuery dbType dbType printedValue    
+        Assert.Equal<string>(expected, actual = (^cmd : (member ToTraceString : ^value -> string) (cmd, value))
+
+    [<Fact>]
+    let traceDate() = 
+        testTraceString (DB.CreateCommand<traceQuery + DATETIME + ")">) DATETIME (System.DateTime.Now) (System.DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff"))
+        
+    [<Fact>]
+    let traceDateTimeOffset() = 
+        testTraceString (DB.CreateCommand<traceQuery + DATETIMEOFFSET + ")">) DATETIMEOFFSET (System.DateTimeOffset.Now) (System.DateTimeOffset.Now.ToString("O"))
+        
+    [<Fact>]
+    let traceTimestamp() =
+        testTraceString (DB.CreateCommand<traceQuery + TIMESTAMP + ")">) TIMESTAMP (System.DateTime.Now.TimeOfDay) (System.DateTime.Now.TimeOfDay.ToString("c"))
+        
+    [<Fact>]
+    let traceInt() =
+        testTraceString (DB.CreateCommand<traceQuery + INT + ")">) INT 42 "42"
+
+    [<Fact>]
+    let traceDecimal() =
+        testTraceString (DB.CreateCommand<traceQuery + DECIMAL63 + ")">) DECIMAL63 123.456m (123.456m.ToString(System.Globalization.CultureInfo.InvariantCulture)
+
+    [<Fact>]
+    let traceNull() =
+        let expected = sprintf "exec sp_executesql N'SELECT CAST(@Value AS NVARCHAR(20))',N'@Value NVARCHAR(20)',@Value=NULL"
+        Assert.Equal<string>(expected, actual = DB.CreateCommand<"SELECT CAST(@Value AS NVARCHAR(20))">.ToTraceString(Unchecked.defaultof<string>))
 
 [<Fact>]
 let resultSetMapping() =

--- a/tests/SqlClient.Tests/CreateCommand.fs
+++ b/tests/SqlClient.Tests/CreateCommand.fs
@@ -97,28 +97,28 @@ module TraceTests =
 
     [<Fact>]
     let traceDate() = 
-        testTraceString (DB.CreateCommand<traceQuery + DATETIME + ")">) DATETIME (System.DateTime.Now) (System.DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff"))
+        testTraceString (DB.CreateCommand<traceQuery + DATETIME + ")">()) DATETIME (System.DateTime.Now) (System.DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff"))
         
     [<Fact>]
     let traceDateTimeOffset() = 
-        testTraceString (DB.CreateCommand<traceQuery + DATETIMEOFFSET + ")">) DATETIMEOFFSET (System.DateTimeOffset.Now) (System.DateTimeOffset.Now.ToString("O"))
+        testTraceString (DB.CreateCommand<traceQuery + DATETIMEOFFSET + ")">()) DATETIMEOFFSET (System.DateTimeOffset.Now) (System.DateTimeOffset.Now.ToString("O"))
         
     [<Fact>]
     let traceTimestamp() =
-        testTraceString (DB.CreateCommand<traceQuery + TIMESTAMP + ")">) TIMESTAMP (System.DateTime.Now.TimeOfDay) (System.DateTime.Now.TimeOfDay.ToString("c"))
+        testTraceString (DB.CreateCommand<traceQuery + TIMESTAMP + ")">()) TIMESTAMP (System.DateTime.Now.TimeOfDay) (System.DateTime.Now.TimeOfDay.ToString("c"))
         
     [<Fact>]
     let traceInt() =
-        testTraceString (DB.CreateCommand<traceQuery + INT + ")">) INT 42 "42"
+        testTraceString (DB.CreateCommand<traceQuery + INT + ")">()) INT 42 "42"
 
     [<Fact>]
     let traceDecimal() =
-        testTraceString (DB.CreateCommand<traceQuery + DECIMAL63 + ")">) DECIMAL63 123.456m (123.456m.ToString(System.Globalization.CultureInfo.InvariantCulture)
+        testTraceString (DB.CreateCommand<traceQuery + DECIMAL63 + ")">()) DECIMAL63 123.456m (123.456m.ToString(System.Globalization.CultureInfo.InvariantCulture)
 
     [<Fact>]
     let traceNull() =
         let expected = sprintf "exec sp_executesql N'SELECT CAST(@Value AS NVARCHAR(20))',N'@Value NVARCHAR(20)',@Value=NULL"
-        Assert.Equal<string>(expected, actual = DB.CreateCommand<"SELECT CAST(@Value AS NVARCHAR(20))">.ToTraceString(Unchecked.defaultof<string>))
+        Assert.Equal<string>(expected, actual = DB.CreateCommand<"SELECT CAST(@Value AS NVARCHAR(20))">().ToTraceString(Unchecked.defaultof<string>))
 
 [<Fact>]
 let resultSetMapping() =

--- a/tests/SqlClient.Tests/CreateCommand.fs
+++ b/tests/SqlClient.Tests/CreateCommand.fs
@@ -108,13 +108,15 @@ module TraceTests =
 
     [<Fact>]
     let traceDate() =     
+        let now = System.DateTime.Now
         testTraceString queryDATETIME (DB.CreateCommand<queryDATETIME>()) DATETIME 
-                        (System.DateTime.Now) (System.DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss.fff"))
+                        now (now.ToString("yyyy-MM-ddTHH:mm:ss.fff"))
     
     [<Fact>]
     let traceDateTimeOffset() = 
+        let now = System.DateTimeOffset.Now
         testTraceString queryDATETIMEOFFSET (DB.CreateCommand<queryDATETIMEOFFSET>()) DATETIMEOFFSET 
-                        (System.DateTimeOffset.Now) (System.DateTimeOffset.Now.ToString("O"))
+                        now (now.ToString("O"))
         
     [<Fact>]
     let traceTimestamp() =

--- a/tests/SqlClient.Tests/CreateCommand.fs
+++ b/tests/SqlClient.Tests/CreateCommand.fs
@@ -113,7 +113,7 @@ module TraceTests =
 
     [<Fact>]
     let traceDecimal() =
-        testTraceString (DB.CreateCommand<traceQuery + DECIMAL63 + ")">()) DECIMAL63 123.456m (123.456m.ToString(System.Globalization.CultureInfo.InvariantCulture)
+        testTraceString (DB.CreateCommand<traceQuery + DECIMAL63 + ")">()) DECIMAL63 123.456m (123.456m.ToString(System.Globalization.CultureInfo.InvariantCulture))
 
     [<Fact>]
     let traceNull() =

--- a/tests/SqlClient.Tests/TypeProviderTest.fs
+++ b/tests/SqlClient.Tests/TypeProviderTest.fs
@@ -136,28 +136,35 @@ let ``Roundtrip ToTraceString for unicode``() =
     let cmd = new SqlCommandProvider<"SELECT CAST(@x AS NVARCHAR(20))", ConnectionStrings.AdventureWorksNamed>()
     let rocket = "🚀"
     let result = runScalarQuery <| cmd.ToTraceString(rocket)      
-    Assert.Equal<string>(expected = rocket, actual = unbox<string> result)
+    Assert.Equal(expected = rocket, actual = unbox<string> result)
     
 [<Fact>]
 let ``Roundtrip ToTraceString for decimals with maximum precision``() = 
     let cmd = new SqlCommandProvider<"SELECT CAST(@x AS DECIMAL(2, 18))", ConnectionStrings.AdventureWorksNamed>()
     let decimal_20_18 = 12345678901234567890.123456789012345678m
     let result = runScalarQuery <| cmd.ToTraceString(decimal_20_18)
-    Assert.Equal<string>(expected = decimal_20_18, actual = unbox<decimal> result
+    Assert.Equal(expected = decimal_20_18, actual = unbox<decimal> result
     
 [<Fact>]
 let ``Roundtrip ToTraceString for date time ``() = 
     let cmd = new SqlCommandProvider<"SELECT CAST(@x AS DATETIME)", ConnectionStrings.AdventureWorksNamed>()
     let now = System.DateTime.Now
     let result = runScalarQuery <| cmd.ToTraceString(now)
-    Assert.Equal<string>(expected = now, actual = unbox<DateTime> result))
+    Assert.Equal(expected = now, actual = unbox<DateTime> result))
 
 [<Fact>]
 let ``Roundtrip ToTraceString for date time offsets``() = 
     let cmd = new SqlCommandProvider<"SELECT CAST(@x AS DATETIMEOFFSET)", ConnectionStrings.AdventureWorksNamed>()
     let now = System.DateTimeOffset.Now
     let result = runScalarQuery <| cmd.ToTraceString(now)
-    Assert.Equal<string>(expected = now, actual = unbox<DateTimeOffset> result)
+    Assert.Equal(expected = now, actual = unbox<DateTimeOffset> result)
+
+[<Fact>]
+let ``Roundtrip ToTraceString for nulls``() = 
+    let cmd = new SqlCommandProvider<"SELECT CAST(@x AS NVARCHAR(20))", ConnectionStrings.AdventureWorksNamed>()
+    let dbnull = Unchecked.defaultof<string>
+    let result = runScalarQuery <| cmd.ToTraceString(dbnull)
+    Assert.Equal(expected = box DBNull.Value, actual = result)
 
 [<Fact>]
 let ``ToTraceString for CRUD``() =    

--- a/tests/SqlClient.Tests/TypeProviderTest.fs
+++ b/tests/SqlClient.Tests/TypeProviderTest.fs
@@ -89,7 +89,7 @@ let singleRowOption() =
 [<Fact>]
 let ToTraceString() =
     let now = DateTime.Now
-    let universalPrintedNow = now.ToString("O")
+    let universalPrintedNow = now.ToString("yyyy-MM-ddTHH:mm:ss.fff")
     let num = 42
     let expected = sprintf "exec sp_executesql N'SELECT CAST(@Date AS DATE), CAST(@Number AS INT)',N'@Date Date,@Number Int',@Date='%s',@Number='%d'" universalPrintedNow num
     let cmd = new SqlCommandProvider<"SELECT CAST(@Date AS DATE), CAST(@Number AS INT)", ConnectionStrings.AdventureWorksNamed, ResultType.Tuples>()
@@ -135,12 +135,12 @@ let ``ToTraceString for xml with single quotes``() =
 let ``ToTraceString for CRUD``() =    
 
     Assert.Equal<string>(
-        expected = "exec sp_executesql N'SELECT CurrencyCode, Name FROM Sales.Currency WHERE CurrencyCode = @code',N'@code NChar(3)',@code='BTC'",
+        expected = "exec sp_executesql N'SELECT CurrencyCode, Name FROM Sales.Currency WHERE CurrencyCode = @code',N'@code NChar(3)',@code=N'BTC'",
         actual = let cmd = new GetBitCoin() in cmd.ToTraceString( bitCoinCode)
     )
     
     Assert.Equal<string>(
-        expected = "exec sp_executesql N'INSERT INTO Sales.Currency VALUES(@Code, @Name, GETDATE())',N'@Code NChar(3),@Name NVarChar(50)',@Code='BTC',@Name='Bitcoin'",
+        expected = "exec sp_executesql N'INSERT INTO Sales.Currency VALUES(@Code, @Name, GETDATE())',N'@Code NChar(3),@Name NVarChar(50)',@Code='BTC',@Name=N'Bitcoin'",
         actual = let cmd = new InsertBitCoin() in cmd.ToTraceString( bitCoinCode, bitCoinName)
     )
 
@@ -160,7 +160,7 @@ let ``ToTraceString double-quotes``() =
 let ``ToTraceString double-quotes in parameter``() =    
     use cmd = new SqlCommandProvider<"SELECT * FROM Sales.Currency WHERE CurrencyCode = @CurrencyCode", ConnectionStrings.AdventureWorksNamed>()    
     Assert.Equal<string>(
-        expected = "exec sp_executesql N'SELECT * FROM Sales.Currency WHERE CurrencyCode = @CurrencyCode',N'@CurrencyCode NChar(3)',@CurrencyCode='A''B'",
+        expected = "exec sp_executesql N'SELECT * FROM Sales.Currency WHERE CurrencyCode = @CurrencyCode',N'@CurrencyCode NChar(3)',@CurrencyCode=N'A''B'",
         actual = cmd.ToTraceString("A'B")
     )
     

--- a/tests/SqlClient.Tests/TypeProviderTest.fs
+++ b/tests/SqlClient.Tests/TypeProviderTest.fs
@@ -148,8 +148,18 @@ let ``Roundtrip ToTraceString for decimals with maximum precision``() =
 [<Fact>]
 let ``Roundtrip ToTraceString for date time ``() = 
     let cmd = new SqlCommandProvider<"SELECT CAST(@x AS DATETIME)", ConnectionStrings.AdventureWorksNamed>()
+    // SQL Server DATETIME has precision up to .00333 seconds
+    let tolerance = 0.00334
     let now = System.DateTime.Now
-    let result = runScalarQuery <| cmd.ToTraceString(now)
+    let result = runScalarQuery <| cmd.ToTraceString(now)    
+    Assert.InRange(unbox<DateTime> result, now.AddSeconds(-1. * tolerance), now.AddSeconds(tolerance))
+
+[<Fact>]
+let ``Roundtrip ToTraceString for datetime2 ``() = 
+    let cmd = new SqlCommandProvider<"SELECT CAST(@x AS DATETIME2)", ConnectionStrings.AdventureWorksNamed>()
+    // SQL Server DATETIME2 has the same nanosecond precision as DATETIMEOFFSET so there shouldn't be any discrepance
+    let now = System.DateTime.Now
+    let result = runScalarQuery <| cmd.ToTraceString(now)    
     Assert.Equal(expected = now, actual = unbox<DateTime> result)
 
 [<Fact>]

--- a/tests/SqlClient.Tests/TypeProviderTest.fs
+++ b/tests/SqlClient.Tests/TypeProviderTest.fs
@@ -140,10 +140,10 @@ let ``Roundtrip ToTraceString for unicode``() =
     
 [<Fact>]
 let ``Roundtrip ToTraceString for decimals with maximum precision``() = 
-    let cmd = new SqlCommandProvider<"SELECT CAST(@x AS DECIMAL(2, 18))", ConnectionStrings.AdventureWorksNamed>()
-    let decimal_20_18 = 12345678901234567890.123456789012345678m
-    let result = runScalarQuery <| cmd.ToTraceString(decimal_20_18)
-    Assert.Equal(expected = decimal_20_18, actual = unbox<decimal> result)
+    let cmd = new SqlCommandProvider<"SELECT CAST(@x AS DECIMAL(38, 18))", ConnectionStrings.AdventureWorksNamed>()
+    let decimal_38_18 = 12345678901234567890.123456789012345678m
+    let result = runScalarQuery <| cmd.ToTraceString(decimal_38_18)
+    Assert.Equal(expected = decimal_38_18, actual = unbox<decimal> result)
     
 [<Fact>]
 let ``Roundtrip ToTraceString for date time ``() = 

--- a/tests/SqlClient.Tests/TypeProviderTest.fs
+++ b/tests/SqlClient.Tests/TypeProviderTest.fs
@@ -98,38 +98,45 @@ let ToTraceString() =
         actual = cmd.ToTraceString( now, num)
     )
     
-let runString query = 
+let runScalarQuery query = 
     use conn = new SqlConnection(ConnectionStrings.AdventureWorks)
     conn.Open()
     use cmd = new System.Data.SqlClient.SqlCommand()
     cmd.Connection <- conn  
     cmd.CommandText <- query
-    cmd.ExecuteNonQuery()
+    cmd.ExecuteScalar()
     
 [<Fact>]
 let ``ToTraceString for dates``() =    
     let cmd = new SqlCommandProvider<"SELECT CAST(@Date AS DATE)", ConnectionStrings.AdventureWorksNamed>()
-    runString <| cmd.ToTraceString(System.DateTime.Now)
+    runScalarQuery <| cmd.ToTraceString(System.DateTime.Now)
     
 [<Fact>]
 let ``ToTraceString for times``() =    
     let cmd = new SqlCommandProvider<"SELECT CAST(@Time AS Time)", ConnectionStrings.AdventureWorksNamed>()
-    runString <| cmd.ToTraceString(System.DateTime.Now.TimeOfDay)
+    runScalarQuery <| cmd.ToTraceString(System.DateTime.Now.TimeOfDay)
     
 [<Fact>]
 let ``ToTraceString for tinyint``() =    
     let cmd = new SqlCommandProvider<"SELECT CAST(@ti AS TINYINT)", ConnectionStrings.AdventureWorksNamed>()
-    runString <| cmd.ToTraceString(0uy)
+    runScalarQuery <| cmd.ToTraceString(0uy)
     
 [<Fact>]
 let ``ToTraceString for xml``() =    
     let cmd = new SqlCommandProvider<"SELECT CAST(@x AS XML)", ConnectionStrings.AdventureWorksNamed>()
-    runString <| cmd.ToTraceString("<foo>bar</foo>")
+    runScalarQuery <| cmd.ToTraceString("<foo>bar</foo>")
     
 [<Fact>]
 let ``ToTraceString for xml with single quotes``() =    
     let cmd = new SqlCommandProvider<"SELECT CAST(@x AS XML)", ConnectionStrings.AdventureWorksNamed>()
-    runString <| cmd.ToTraceString("<foo>b'ar</foo>")    
+    runScalarQuery <| cmd.ToTraceString("<foo>b'ar</foo>")  
+    
+[<Fact>]
+let ``ToTraceString for unicode``() =    
+    let cmd = new SqlCommandProvider<"SELECT CAST(@x AS NVARCHAR(20))", ConnectionStrings.AdventureWorksNamed>()
+    let rocket = runScalarQuery <| cmd.ToTraceString("🚀")      
+    Assert.Equal<string>(expected = "🚀", actual = unbox<string> rocket)
+    
 
 [<Fact>]
 let ``ToTraceString for CRUD``() =    

--- a/tests/SqlClient.Tests/TypeProviderTest.fs
+++ b/tests/SqlClient.Tests/TypeProviderTest.fs
@@ -143,7 +143,7 @@ let ``Roundtrip ToTraceString for decimals with maximum precision``() =
     let cmd = new SqlCommandProvider<"SELECT CAST(@x AS DECIMAL(2, 18))", ConnectionStrings.AdventureWorksNamed>()
     let decimal_20_18 = 12345678901234567890.123456789012345678m
     let result = runScalarQuery <| cmd.ToTraceString(decimal_20_18)
-    Assert.Equal(expected = decimal_20_18, actual = unbox<decimal> result
+    Assert.Equal(expected = decimal_20_18, actual = unbox<decimal> result)
     
 [<Fact>]
 let ``Roundtrip ToTraceString for date time ``() = 

--- a/tests/SqlClient.Tests/TypeProviderTest.fs
+++ b/tests/SqlClient.Tests/TypeProviderTest.fs
@@ -150,7 +150,7 @@ let ``Roundtrip ToTraceString for date time ``() =
     let cmd = new SqlCommandProvider<"SELECT CAST(@x AS DATETIME)", ConnectionStrings.AdventureWorksNamed>()
     let now = System.DateTime.Now
     let result = runScalarQuery <| cmd.ToTraceString(now)
-    Assert.Equal(expected = now, actual = unbox<DateTime> result))
+    Assert.Equal(expected = now, actual = unbox<DateTime> result)
 
 [<Fact>]
 let ``Roundtrip ToTraceString for date time offsets``() = 

--- a/tests/SqlClient.Tests/TypeProviderTest.fs
+++ b/tests/SqlClient.Tests/TypeProviderTest.fs
@@ -140,10 +140,12 @@ let ``Roundtrip ToTraceString for unicode``() =
     
 [<Fact>]
 let ``Roundtrip ToTraceString for decimals with maximum precision``() = 
-    let cmd = new SqlCommandProvider<"SELECT CAST(@x AS DECIMAL(38, 18))", ConnectionStrings.AdventureWorksNamed>()
-    let decimal_38_18 = 12345678901234567890.123456789012345678m
-    let result = runScalarQuery <| cmd.ToTraceString(decimal_38_18)
-    Assert.Equal(expected = decimal_38_18, actual = unbox<decimal> result)
+    // Note: maximum precision for MSSQL decimals is 38, but maximum for MSSQL <-> .NET conversion is 29
+    // https://weblogs.sqlteam.com/mladenp/2010/08/31/when-does-sql-server-decimal-not-convert-to-net-decimal/
+    let cmd = new SqlCommandProvider<"SELECT CAST(@x AS DECIMAL(29, 19))", ConnectionStrings.AdventureWorksNamed>()
+    let decimal_29_19 = 1234567890.1234567890123456789m
+    let result = runScalarQuery <| cmd.ToTraceString(decimal_29_19)
+    Assert.Equal(expected = decimal_29_19, actual = unbox<decimal> result)
     
 [<Fact>]
 let ``Roundtrip ToTraceString for date time ``() = 

--- a/tests/SqlClient.Tests/TypeProviderTest.fs
+++ b/tests/SqlClient.Tests/TypeProviderTest.fs
@@ -91,7 +91,7 @@ let ToTraceString() =
     let now = DateTime.Now
     let universalPrintedNow = now.ToString("yyyy-MM-ddTHH:mm:ss.fff")
     let num = 42
-    let expected = sprintf "exec sp_executesql N'SELECT CAST(@Date AS DATE), CAST(@Number AS INT)',N'@Date Date,@Number Int',@Date='%s',@Number='%d'" universalPrintedNow num
+    let expected = sprintf "exec sp_executesql N'SELECT CAST(@Date AS DATE), CAST(@Number AS INT)',N'@Date Date,@Number Int',@Date=N'%s',@Number=N'%d'" universalPrintedNow num
     let cmd = new SqlCommandProvider<"SELECT CAST(@Date AS DATE), CAST(@Number AS INT)", ConnectionStrings.AdventureWorksNamed, ResultType.Tuples>()
     Assert.Equal<string>(
         expected, 
@@ -140,12 +140,12 @@ let ``ToTraceString for CRUD``() =
     )
     
     Assert.Equal<string>(
-        expected = "exec sp_executesql N'INSERT INTO Sales.Currency VALUES(@Code, @Name, GETDATE())',N'@Code NChar(3),@Name NVarChar(50)',@Code='BTC',@Name=N'Bitcoin'",
+        expected = "exec sp_executesql N'INSERT INTO Sales.Currency VALUES(@Code, @Name, GETDATE())',N'@Code NChar(3),@Name NVarChar(50)',@Code=N'BTC',@Name=N'Bitcoin'",
         actual = let cmd = new InsertBitCoin() in cmd.ToTraceString( bitCoinCode, bitCoinName)
     )
 
     Assert.Equal<string>(
-        expected = "exec sp_executesql N'DELETE FROM Sales.Currency WHERE CurrencyCode = @Code',N'@Code NChar(3)',@Code='BTC'",
+        expected = "exec sp_executesql N'DELETE FROM Sales.Currency WHERE CurrencyCode = @Code',N'@Code NChar(3)',@Code=N'BTC'",
         actual = let cmd = new DeleteBitCoin() in cmd.ToTraceString( bitCoinCode)
     )
     

--- a/tests/SqlClient.Tests/TypeProviderTest.fs
+++ b/tests/SqlClient.Tests/TypeProviderTest.fs
@@ -132,11 +132,32 @@ let ``ToTraceString for xml with single quotes``() =
     runScalarQuery <| cmd.ToTraceString("<foo>b'ar</foo>")  
     
 [<Fact>]
-let ``ToTraceString for unicode``() =    
+let ``Roundtrip ToTraceString for unicode``() =    
     let cmd = new SqlCommandProvider<"SELECT CAST(@x AS NVARCHAR(20))", ConnectionStrings.AdventureWorksNamed>()
-    let rocket = runScalarQuery <| cmd.ToTraceString("🚀")      
-    Assert.Equal<string>(expected = "🚀", actual = unbox<string> rocket)
+    let rocket = "🚀"
+    let result = runScalarQuery <| cmd.ToTraceString(rocket)      
+    Assert.Equal<string>(expected = rocket, actual = unbox<string> result)
     
+[<Fact>]
+let ``Roundtrip ToTraceString for decimals with maximum precision``() = 
+    let cmd = new SqlCommandProvider<"SELECT CAST(@x AS DECIMAL(2, 18))", ConnectionStrings.AdventureWorksNamed>()
+    let decimal_20_18 = 12345678901234567890.123456789012345678m
+    let result = runScalarQuery <| cmd.ToTraceString(decimal_20_18)
+    Assert.Equal<string>(expected = decimal_20_18, actual = unbox<decimal> result
+    
+[<Fact>]
+let ``Roundtrip ToTraceString for date time ``() = 
+    let cmd = new SqlCommandProvider<"SELECT CAST(@x AS DATETIME)", ConnectionStrings.AdventureWorksNamed>()
+    let now = System.DateTime.Now
+    let result = runScalarQuery <| cmd.ToTraceString(now)
+    Assert.Equal<string>(expected = now, actual = unbox<DateTime> result))
+
+[<Fact>]
+let ``Roundtrip ToTraceString for date time offsets``() = 
+    let cmd = new SqlCommandProvider<"SELECT CAST(@x AS DATETIMEOFFSET)", ConnectionStrings.AdventureWorksNamed>()
+    let now = System.DateTimeOffset.Now
+    let result = runScalarQuery <| cmd.ToTraceString(now)
+    Assert.Equal<string>(expected = now, actual = unbox<DateTimeOffset> result)
 
 [<Fact>]
 let ``ToTraceString for CRUD``() =    


### PR DESCRIPTION
Thanks for merging the previous PR. I've addressed some more issues with the commands created by `ToTraceString`:

 - String parameters are now also preceded by `N` to correctly escape Unicode characters 
 - Numeric parameters are printed in culture-invariant format
 - The ISO-8601 timestamp format works for `datetimeoffset` and `datetime2` fields, but for older  `datetime` fields it's not guaranteed to work and is best encoded as `yyyy-MM-ddTHH:mm:ss.fff`  (see [this](https://dba.stackexchange.com/questions/63641/understanding-datetime-formats-in-sql-server) SO answer)
 - Decimal parameters are declared with precision and scale. This prevents them from being silently rounded to integers
 - Nulls are printed as literal NULLs

