### PR TITLE
Adding parameter -d to sqlcmd

### DIFF
--- a/docs/content/dynamic local db.fsx
+++ b/docs/content/dynamic local db.fsx
@@ -65,7 +65,7 @@ your project (you can place it in the project root too, if you want):
     sqlcmd -S "(LocalDB)\MSSQLLocalDB" -i "createdb.sql"
     Remove-Item "createdb.sql"
 
-    sqlcmd -S "(LocalDB)\MSSQLLocalDB" -i "$DbScript"
+    sqlcmd -S "(LocalDB)\MSSQLLocalDB" -i "$DbScript" -d "$DbName"
 
     $detach_db_sql | Out-File "detachdb.sql"
     sqlcmd -S "(LocalDB)\MSSQLLocalDB" -i "detachdb.sql"


### PR DESCRIPTION
Adding parameter `-d "$DbName"` so the script does not need to include `USE` command.

If source database has a different name `USE` command will fail and objects will be created in master.