### PR TITLE
remove type provider SDK files from SqlClient.fsproj

### DIFF
--- a/src/SqlClient.DesignTime/SqlClient.DesignTime.fsproj
+++ b/src/SqlClient.DesignTime/SqlClient.DesignTime.fsproj
@@ -9,6 +9,7 @@
     <NoWarn>101</NoWarn>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
+    <DefineConstants>$(DefineConstants);DESIGNTIME_CODE_ONLY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.1.18" Condition="'$(TargetFramework)' == 'net40'" />

--- a/src/SqlClient/Shared.fs
+++ b/src/SqlClient/Shared.fs
@@ -78,7 +78,7 @@ type [<DataContract;CLIMutable>] Column = {
         if this.Nullable
         then typedefof<_ option>.MakeGenericType this.TypeInfo.ClrType
         else this.TypeInfo.ClrType
-    
+#if DESIGNTIME_CODE_ONLY
     member this.GetProvidedType(unitsOfMeasurePerSchema: IDictionary<string, ProviderImplementation.ProvidedTypes.ProvidedTypeDefinition list>) = 
         let typeConsideringUOM: Type = 
             if this.TypeInfo.IsUnitOfMeasure
@@ -99,7 +99,7 @@ type [<DataContract;CLIMutable>] Column = {
             typedefof<_ option>.MakeGenericType typeConsideringUOM
         else 
             typeConsideringUOM
-
+#endif
     member this.HasDefaultConstraint = this.DefaultConstraint <> ""
     member this.NullableParameter = this.Nullable || this.HasDefaultConstraint
     member this.GetTypeInfoConsideringUDDT() =
@@ -175,7 +175,7 @@ type [<DataContract;CLIMutable>] Parameter = {
         match this.TypeInfo.SqlDbType with
         | SqlDbType.NChar | SqlDbType.NText | SqlDbType.NVarChar -> this.MaxLength / 2
         | _ -> this.MaxLength
-
+#if DESIGNTIME_CODE_ONLY
     member this.GetProvidedType(unitsOfMeasurePerSchema: IDictionary<string, ProviderImplementation.ProvidedTypes.ProvidedTypeDefinition list>) = 
         if this.TypeInfo.IsUnitOfMeasure
         then
@@ -183,7 +183,7 @@ type [<DataContract;CLIMutable>] Parameter = {
             ProviderImplementation.ProvidedTypes.ProvidedMeasureBuilder.AnnotateType(this.TypeInfo.ClrType, [ uomType ])
         else
             this.TypeInfo.ClrType
-
+#endif
 type TempTableLoader(fieldCount, items: obj seq) =
     let enumerator = items.GetEnumerator()
 

--- a/src/SqlClient/SqlClient.fsproj
+++ b/src/SqlClient/SqlClient.fsproj
@@ -28,12 +28,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
-    <Compile Include="..\..\paket-files\fsprojects\FSharp.TypeProviders.SDK\src\ProvidedTypes.fsi">
-      <Link>paket-files/ProvidedTypes.fsi</Link>
-    </Compile>
-    <Compile Include="..\..\paket-files\fsprojects\FSharp.TypeProviders.SDK\src\ProvidedTypes.fs">
-      <Link>paket-files/ProvidedTypes.fs</Link>
-    </Compile>
     <Compile Include="Extensions.fs" />
     <Compile Include="Shared.fs" />
     <Compile Include="Configuration.fs" />


### PR DESCRIPTION
Not used at runtime and saves compile time.